### PR TITLE
Allow options hash to be passed in initializer to all strategies.

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/facebook.rb
+++ b/oa-oauth/lib/omniauth/strategies/facebook.rb
@@ -16,8 +16,11 @@ module OmniAuth
     # <tt>:scope</tt> :: Extended permissions such as <tt>email</tt> and <tt>offline_access</tt> (which are the defaults).
     class Facebook < OAuth2
       def initialize(app, app_id, app_secret, options = {})
-        options[:site] = 'https://graph.facebook.com/'
-        super(app, :facebook, app_id, app_secret, options)
+        local_options = {
+          :site => 'https://graph.facebook.com/'
+        }
+        local_options.merge!(options)
+        super(app, :facebook, app_id, app_secret, local_options)
       end
       
       def user_data

--- a/oa-oauth/lib/omniauth/strategies/foursquare.rb
+++ b/oa-oauth/lib/omniauth/strategies/foursquare.rb
@@ -2,8 +2,11 @@ module OmniAuth
   module Strategies
     class Foursquare < OAuth
       def initialize(app, consumer_key, consumer_secret, options = {})
-        options[:site] = 'http://foursquare.com'
-        super(app, :foursquare, consumer_key, consumer_secret, options)
+        local_options = {
+          :site => 'http://foursquare.com'
+        }
+        local_options.merge!(options)
+        super(app, :foursquare, consumer_key, consumer_secret, local_options)
       end
       
       def auth_hash

--- a/oa-oauth/lib/omniauth/strategies/github.rb
+++ b/oa-oauth/lib/omniauth/strategies/github.rb
@@ -5,10 +5,13 @@ module OmniAuth
   module Strategies
     class GitHub < OAuth2
       def initialize(app, app_id, app_secret, options = {})
-        options[:site] = 'https://github.com/'
-        options[:authorize_path] = '/login/oauth/authorize'
-        options[:access_token_path] = '/login/oauth/access_token'
-        super(app, :github, app_id, app_secret, options)
+        local_options = {
+          :site => 'https://github.com/',
+          :authorize_path => '/login/oauth/authorize',
+          :access_token_path => '/login/oauth/access_token'
+        }
+        local_options.merge!(options)
+        super(app, :github, app_id, app_secret, local_options)
       end
       
       def user_data

--- a/oa-oauth/lib/omniauth/strategies/linked_in.rb
+++ b/oa-oauth/lib/omniauth/strategies/linked_in.rb
@@ -5,12 +5,15 @@ module OmniAuth
   module Strategies
     class LinkedIn < OmniAuth::Strategies::OAuth
       def initialize(app, consumer_key, consumer_secret, options = {})
-        options[:site] = 'https://api.linkedin.com'
-        options[:request_token_path] = '/uas/oauth/requestToken'
-        options[:access_token_path] = '/uas/oauth/accessToken'
-        options[:authorize_path] = '/uas/oauth/authorize'
-        options[:scheme] = :header
-        super(app, :linked_in, consumer_key, consumer_secret, options)
+        local_options = {
+          :site => 'https://api.linkedin.com',
+          :request_token_path => '/uas/oauth/requestToken',
+          :access_token_path => '/uas/oauth/accessToken',
+          :authorize_path => '/uas/oauth/authorize',
+          :scheme => :header
+        }
+        local_options.merge!(options)
+        super(app, :linked_in, consumer_key, consumer_secret, local_options)
       end
       
       def auth_hash

--- a/oa-oauth/lib/omniauth/strategies/thirty_seven_signals.rb
+++ b/oa-oauth/lib/omniauth/strategies/thirty_seven_signals.rb
@@ -5,10 +5,13 @@ module OmniAuth
   module Strategies
     class ThirtySevenSignals < OAuth2
       def initialize(app, app_id, app_secret, options = {})
-        options[:site] = 'https://launchpad.37signals.com/'
-        options[:authorize_path] = '/authorization/new'
-        options[:access_token_path] = '/authorization/token'
-        super(app, :thirty_seven_signals, app_id, app_secret, options)
+        local_options = {
+          :site => 'https://launchpad.37signals.com/',
+          :authorize_path => '/authorization/new',
+          :access_token_path => '/authorization/token'
+        }
+        local_options.merge!(options)
+        super(app, :thirty_seven_signals, app_id, app_secret, local_options)
       end
       
       def user_data

--- a/oa-oauth/lib/omniauth/strategies/twitter.rb
+++ b/oa-oauth/lib/omniauth/strategies/twitter.rb
@@ -13,8 +13,11 @@ module OmniAuth
     #
     class Twitter < OmniAuth::Strategies::OAuth
       def initialize(app, consumer_key, consumer_secret, options = {})
-        options[:site] = 'https://api.twitter.com'
-        super(app, :twitter, consumer_key, consumer_secret, options)
+        local_options = {
+          :site => 'https://api.twitter.com'
+        }
+        local_options.merge!(options)
+        super(app, :twitter, consumer_key, consumer_secret, local_options)
       end
       
       def auth_hash


### PR DESCRIPTION
I needed this to allow me to change the authorize_url for Foursquare and Twitter to /oauth/athenticate instead of /oauth/authorize, but it should be generally useful.
