### PR TITLE
Foursquare authenticate endpoint, mobile authorize, specs

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/foursquare.rb
+++ b/oa-oauth/lib/omniauth/strategies/foursquare.rb
@@ -1,9 +1,10 @@
 module OmniAuth
   module Strategies
     class Foursquare < OAuth
-      def initialize(app, consumer_key, consumer_secret)
+      def initialize(app, consumer_key, consumer_secret, opts={})
         super(app, :foursquare, consumer_key, consumer_secret,
-                :site => 'http://foursquare.com')
+                :site => 'http://foursquare.com',
+                :authorize_path => opts[:mobile] ? '/mobile/oauth/authenticate' : '/oauth/authenticate')
       end
       
       def auth_hash

--- a/oa-oauth/spec/omniauth/strategies/foursquare_spec.rb
+++ b/oa-oauth/spec/omniauth/strategies/foursquare_spec.rb
@@ -1,0 +1,28 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe 'OmniAuth::Strategies::Foursquare' do
+  
+  it 'should subclass OAuth' do
+    OmniAuth::Strategies::Foursquare.should < OmniAuth::Strategies::OAuth
+  end
+  
+  it 'should initialize with just consumer key and secret' do
+    lambda{OmniAuth::Strategies::Foursquare.new({},'abc','def')}.should_not raise_error
+  end
+  
+  let(:foursquare) { OmniAuth::Strategies::Foursquare.new({},'abc','def') }
+  
+  it "should use the authenticate endpoint" do
+    foursquare.consumer.authorize_path.should == '/oauth/authenticate'
+    foursquare.consumer.authorize_url.should == 'http://foursquare.com/oauth/authenticate'
+  end
+  
+  context "mobile version" do
+    let(:foursquare) { OmniAuth::Strategies::Foursquare.new({},'abc','def', :mobile => true) }
+    
+    it "should use the mobile authenticate endpoint" do
+      foursquare.consumer.authorize_path.should == '/mobile/oauth/authenticate'
+      foursquare.consumer.authorize_url.should == 'http://foursquare.com/mobile/oauth/authenticate'
+    end
+  end
+end


### PR DESCRIPTION
Re: issue #36

After reading the code a little more, realized that the way that was done was stupid, this one is more sane.
- Foursquare authorize path is now /oauth/authenticate rather than /oauth/authorize, this endpoint supports automatic redirects if the user has already authorized your application.
- Adds support for the mobile optimized /authorized endpoint, used like so:
  
    config.middleware.use OmniAuth::Builder do
      provider :foursquare, 'CONSUMER_KEY', 'CONSUMER_SECRET', :mobile => true
    end
- Adds specs for the Foursquare strategy, and for these changes
