### PR TITLE
Raise oauth2 gem dependency to 0.1.0

### DIFF
--- a/oa-oauth/oa-oauth.gemspec
+++ b/oa-oauth/oa-oauth.gemspec
@@ -10,14 +10,14 @@ Gem::Specification.new do |gem|
   gem.email = "michael@intridea.com"
   gem.homepage = "http://github.com/intridea/omniauth"
   gem.authors = ["Michael Bleigh"]
-  
+
   gem.files = Dir.glob("{lib}/**/*") + %w(README.rdoc LICENSE.rdoc CHANGELOG.rdoc)
-  
+
   gem.add_dependency  'oa-core',    version
   gem.add_dependency  'multi_json', '~> 0.0.2'
   gem.add_dependency  'nokogiri',   '~> 1.4.2'
   gem.add_dependency  'oauth',      '~> 0.4.0'
-  gem.add_dependency  'oauth2',     '~> 0.0.10'
-  
+  gem.add_dependency  'oauth2',     '~> 0.1.0'
+
   eval File.read(File.join(File.dirname(__FILE__), '../development_dependencies.rb'))
 end


### PR DESCRIPTION
This fixes an issue with the twitter gem.  The twitter gem uses Faraday ~0.5.1, but due to the oauth2 gem, bundler uses 0.4.6.
