### PR TITLE
Facebook iFrame Applications Redirect Fix

### DIFF
--- a/oa-core/lib/omniauth/strategy.rb
+++ b/oa-core/lib/omniauth/strategy.rb
@@ -77,8 +77,15 @@ module OmniAuth
     end
     
     def redirect(uri)
-      r = Rack::Response.new("Redirecting to #{uri}...")
-      r.redirect(uri)
+      r = Rack::Response.new
+
+      if options[:iframe]
+        r.write("<script type='text/javascript' charset='utf-8'>top.location.href = '#{uri}';</script>")
+      else
+        r.write("Redirecting to #{uri}...")
+        r.redirect(uri)
+      end
+      
       r.finish
     end
     


### PR DESCRIPTION
In some cases Facebook iframe applications fail as Facebook would try and load itself into the iframe. By adding ":iframe => true" to the options, Omniauth will force the redirect out of the current frame and into the top window.
