### PR TITLE
Google OpenID

### DIFF
--- a/oa-core/lib/omniauth/core.rb
+++ b/oa-core/lib/omniauth/core.rb
@@ -57,6 +57,7 @@ module OmniAuth
       'oauth' => 'OAuth',
       'oauth2' => 'OAuth2',
       'openid' => 'OpenID',
+      'google_open_id' => 'GoogleOpenID',
       'open_id' => 'OpenID',
       'github' => 'GitHub',
       'tripit' => 'TripIt',

--- a/oa-openid/lib/omniauth/openid.rb
+++ b/oa-openid/lib/omniauth/openid.rb
@@ -38,6 +38,7 @@ module OmniAuth
   # 
   #     use OmniAuth::Builder do
   #       provider :open_id, OpenID::Store::Filesystem.new('/tmp')
+  #       provider :google_open_id
   #       provider :campfire
   #     end
   # 
@@ -50,10 +51,11 @@ module OmniAuth
   #     end
   # 
   # Note the use of nil, which will trigger ruby-openid's default Memory Store.
+
   module OpenID; end
-  
   module Strategies
     autoload :OpenID, 'omniauth/strategies/open_id'
     autoload :GoogleApps, 'omniauth/strategies/google_apps'
+    autoload :GoogleOpenID, 'omniauth/strategies/google_open_id'
   end
 end

--- a/oa-openid/lib/omniauth/strategies/google_open_id.rb
+++ b/oa-openid/lib/omniauth/strategies/google_open_id.rb
@@ -1,0 +1,28 @@
+require 'omniauth/openid'
+
+module OmniAuth
+  module Strategies
+    class GoogleOpenID < OmniAuth::Strategies::OpenID
+
+      # OmniAuth::Strategies::GoogleOpenID helps you
+      # to use plain open_id and google open_id both in the same application
+      #
+      #     use OmniAuth::Builder do
+      #       provider :google_open_id
+      #       provider :open_id, OpenID::Store::Filesystem.new('/tmp')
+      #     end
+      #
+
+      def initialize(app, store = nil, options = {})
+        options[:name]||='google_open_id'
+        super(app, store, options)
+      end
+
+      
+      def identifier
+        'https://www.google.com/accounts/o8/id'
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
I've added the Google Open ID proxy strategy. It's easy way to use it both with plain open_id:

provider :open_id, OpenID::Store::Filesystem.new('/tmp')
provider :google_open_id
