### PR TITLE
Added profile image to Facebook strategy

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/facebook.rb
+++ b/oa-oauth/lib/omniauth/strategies/facebook.rb
@@ -32,6 +32,7 @@ module OmniAuth
           'first_name' => user_data["first_name"],
           'last_name' => user_data["last_name"],
           'name' => "#{user_data['first_name']} #{user_data['last_name']}",
+          'image' => "http://graph.facebook.com/#{user_data['id']}/picture?type=square",
           'urls' => {
             'Facebook' => user_data["link"],
             'Website' => user_data["website"],


### PR DESCRIPTION
Added user_info[:image] to the auth hash for the Facebook strategy.  It's value is the graph URL for the users profile picture as documented here http://developers.facebook.com/docs/api#pictures.
