### PR TITLE
Foursquare strategy wasn't working

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/foursquare.rb
+++ b/oa-oauth/lib/omniauth/strategies/foursquare.rb
@@ -1,3 +1,6 @@
+require 'omniauth/oauth'
+require 'multi_json'
+
 module OmniAuth
   module Strategies
     class Foursquare < OAuth


### PR DESCRIPTION
Hi,

I've made one tiny update to the Foursquare strategy in oa-oauth. Without requiring the two files at the top, like in the Twitter strategy, trying to complete the OAuth dance with Foursquare in a Sinatra app was failing for me.

Let me know if there is anything else I can do.

Thanks!

Phil
