### PR TITLE
Adding Basic Specs for GitHub & LinkedIn Strategies

### DIFF
--- a/oa-oauth/spec/omniauth/strategies/github_spec.rb
+++ b/oa-oauth/spec/omniauth/strategies/github_spec.rb
@@ -1,0 +1,5 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe OmniAuth::Strategies::GitHub do
+  it_should_behave_like "an oauth2 strategy"
+end

--- a/oa-oauth/spec/omniauth/strategies/linked_in_spec.rb
+++ b/oa-oauth/spec/omniauth/strategies/linked_in_spec.rb
@@ -1,0 +1,5 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe OmniAuth::Strategies::LinkedIn do
+  it_should_behave_like "an oauth strategy"
+end


### PR DESCRIPTION
Since neither of these oauth strategies had specs I went ahead and added the basic shared specs for each.
