### PR TITLE
Test mode clobbering homepage

### DIFF
--- a/oa-core/lib/omniauth/strategy.rb
+++ b/oa-core/lib/omniauth/strategy.rb
@@ -48,6 +48,8 @@ module OmniAuth
       elsif request.path == callback_path
         @env['omniauth.auth'] = OmniAuth.mock_auth_for(name.to_sym)
         call_app!
+      else
+        call_app!
       end
     end
     

--- a/oa-core/spec/omniauth/strategy_spec.rb
+++ b/oa-core/spec/omniauth/strategy_spec.rb
@@ -142,6 +142,11 @@ describe OmniAuth::Strategy do
         response[1]['Location'].should == '/auth/test/callback'
       end
 
+      it 'should not short circuit requests outside of authentication' do
+        env = {'PATH_INFO' => '/'}
+        strategy.call(env).should == app.call(env)
+      end
+
       it 'should respond with the default hash if none is set' do
         strategy.call 'PATH_INFO' => '/auth/test/callback'
         strategy.env['omniauth.auth']['uid'].should == '1234'


### PR DESCRIPTION
Great work on omniauth. Really looking forward to the 0.2.0 release. I had some trouble with your new wiki instructions regarding integration testing. I wrote this Cucumber scenario:

```
Scenario:
  Given I am logged in on GitHub
  When I go to the homepage
  And I follow "Log In"
  Then I should be on the user page
  And I should see "Logged In!"
```

where the first step looks like:

```
Given 'I am logged in on GitHub' do
  OmniAuth.config.test_mode = true
  OmniAuth.config.mock_auth[:github] = {
    'uid' => '123',
    'user_info' => {
      'name' => 'Steve Richert',
      'email' => 'steve.richert@gmail.com',
      'nickname' => 'laserlemon'
    }
  }
end
```

The problem is that after setting OmniAuth's test mode to true, the next request to the homepage was returning `nil` rather than a standard status-headers-body rack response. I added a failing test and fixed the issue.
