### PR TITLE
Password strategy's options were being ignored

### DIFF
--- a/oa-core/lib/omniauth/strategies/password.rb
+++ b/oa-core/lib/omniauth/strategies/password.rb
@@ -7,9 +7,8 @@ module OmniAuth
       include OmniAuth::Strategy
       
       def initialize(app, secret = 'changethisappsecret', options = {}, &block)
-        @options = options
         @secret = secret
-        super(app, :password, &block)
+        super(app, :password, options, &block)
       end
 
       attr_reader :secret

--- a/oa-core/lib/omniauth/test/strategy_macros.rb
+++ b/oa-core/lib/omniauth/test/strategy_macros.rb
@@ -22,6 +22,11 @@ module OmniAuth
         end
       end
       
+      def sets_user_info_to(user_info)
+        it "should set the user_info to #{user_info}" do
+          (last_request.env['omniauth.auth'] || {})['user_info'].should == user_info
+        end
+      end
     end
     
   end

--- a/oa-core/spec/omniauth/strategies/password_spec.rb
+++ b/oa-core/spec/omniauth/strategies/password_spec.rb
@@ -27,6 +27,7 @@ describe OmniAuth::Strategies::Password, :type => :strategy do
     end
     sets_an_auth_hash
     sets_provider_to 'password'
+    sets_user_info_to "username" => "jerome"
     it 'should set the UID to an opaque identifier' do
       uid = last_request.env['omniauth.auth']['uid']
       uid.should_not be_nil


### PR DESCRIPTION
Hey everyone,

I was working with the Password strategy and found that its @options were being overridden, so setting the :identifier_key didn't change anything (despite what the docs and spec say). This commit fixes that by adding "options" to the super call and adds a macro to spec the user_info hash (not that I'll be heartbroken if you don't take it...).

Thanks,
Andrew
