### PR TITLE
Linkedin authenticate

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/linked_in.rb
+++ b/oa-oauth/lib/omniauth/strategies/linked_in.rb
@@ -9,7 +9,7 @@ module OmniAuth
                 {:site => 'https://api.linkedin.com',
                 :request_token_path => '/uas/oauth/requestToken',
                 :access_token_path => '/uas/oauth/accessToken',
-                :authorize_path => '/uas/oauth/authorize',
+                :authorize_path => '/uas/oauth/authenticate',
                 :scheme => :header}, options, &block)
       end
       


### PR DESCRIPTION
The sign-in process is much smoother if you use LinkedIn's "/uas/oauth/authenticate" endpoint, rather than "/uas/oauth/authorize".

http://developer.linkedin.com/community/apis/blog/2010/04/29/oauth--now-for-authentication
