### PR TITLE
Dynamic providers - client keys are not modified during the callback phase

### DIFF
--- a/oa-core/lib/omniauth/strategy.rb
+++ b/oa-core/lib/omniauth/strategy.rb
@@ -1,33 +1,32 @@
 require 'omniauth/core'
 
 module OmniAuth
-  class NoSessionError < StandardError; end 
-  module Strategy 
+  class NoSessionError < StandardError; end
+  module Strategy
     def self.included(base)
       OmniAuth.strategies << base
       base.class_eval do
         attr_reader :app, :name, :env, :options, :response
       end
     end
-     
+
     def initialize(app, name, *args, &block)
       @app = app
       @name = name.to_sym
       @options = args.last.is_a?(Hash) ? args.pop : {}
-      
+
       yield self if block_given?
     end
-    
+
     def call(env)
       dup.call!(env)
     end
 
     def call!(env)
       raise OmniAuth::NoSessionError.new("You must provide a session to use OmniAuth.") unless env['rack.session']
-
       @env = env
       return mock_call!(env) if OmniAuth.config.test_mode
-      
+
       if current_path == request_path && OmniAuth.config.allowed_request_methods.include?(request.request_method.downcase.to_sym)
         if response = call_through_to_app
           response
@@ -38,8 +37,11 @@ module OmniAuth
       elsif current_path == callback_path
         env['omniauth.origin'] = session.delete('omniauth.origin')
         env['omniauth.origin'] = nil if env['omniauth.origin'] == ''
-
-        callback_phase
+        if response = call_through_to_app
+          response
+        else
+          callback_phase
+        end
       else
         if respond_to?(:other_phase)
           other_phase
@@ -50,7 +52,7 @@ module OmniAuth
     end
 
     def mock_call!(env)
-      if current_path == request_path 
+      if current_path == request_path
         if response = call_through_to_app
           response
         else
@@ -64,24 +66,24 @@ module OmniAuth
         call_app!
       end
     end
-    
+
     def request_phase
       raise NotImplementedError
     end
-    
+
     def callback_phase
       @env['omniauth.auth'] = auth_hash
-      call_app! 
+      call_app!
     end
-    
+
     def path_prefix
       options[:path_prefix] || OmniAuth.config.path_prefix
     end
-    
+
     def request_path
       options[:request_path] || "#{path_prefix}/#{name}"
     end
-    
+
     def callback_path
       options[:callback_path] || "#{path_prefix}/#{name}/callback"
     end
@@ -93,26 +95,30 @@ module OmniAuth
     def query_string
       request.query_string.empty? ? "" : "?#{request.query_string}"
     end
-    
+
     def call_through_to_app
-      status, headers, body = *call_app!
+      status, headers, body = *call_app!(request_path)
       @response = Rack::Response.new(body, status, headers)
-      
+
       status == 404 ? nil : @response.finish
     end
 
-    def call_app!
-      @env['omniauth.strategy'] = self      
-      @app.call(@env)
+    def call_app!(path_info = nil)
+      @env['omniauth.strategy'] = self
+      last_path_info = @env['PATH_INFO']
+      @env['PATH_INFO'] = path_info if path_info
+      result = @app.call(@env)
+      @env['PATH_INFO'] = last_path_info
+      result
     end
-    
+
     def auth_hash
       {
         'provider' => name.to_s,
         'uid' => nil
       }
     end
-    
+
     def full_host
       case OmniAuth.config.full_host
         when String
@@ -126,11 +132,11 @@ module OmniAuth
           uri.to_s
       end
     end
-    
+
     def callback_url
       full_host + callback_path + query_string
     end
-    
+
     def session
       @env['rack.session']
     end
@@ -138,7 +144,7 @@ module OmniAuth
     def request
       @request ||= Rack::Request.new(@env)
     end
-    
+
     def redirect(uri)
       r = Rack::Response.new
 
@@ -148,17 +154,17 @@ module OmniAuth
         r.write("Redirecting to #{uri}...")
         r.redirect(uri)
       end
-      
+
       r.finish
     end
-    
+
     def user_info; {} end
-    
+
     def fail!(message_key, exception = nil)
       self.env['omniauth.error'] = exception
       self.env['omniauth.error.type'] = message_key.to_sym
       self.env['omniauth.error.strategy'] = self
-      
+
       OmniAuth.config.on_failure.call(self.env)
     end
   end


### PR DESCRIPTION
We're using 0.2.0.beta4 because we need to be able to change Facebook keys based on the current subdomain. Here's the code we got right now:

```
def facebook
  request.env['omniauth.strategy'].client_id = current_site.facebook_app_id
  request.env['omniauth.strategy'].client_secret = current_site.facebook_app_secret
  render :text => "Setup complete.", :status => 404
end
```

It works fine for the request phase, but the authentication itself always fails. During the callback phase these settings are no longer present, so when the strategy calls client, it's instantiated with the default (empty in our case) keys.
