### PR TITLE
Google auth and scope error

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/google.rb
+++ b/oa-oauth/lib/omniauth/strategies/google.rb
@@ -20,8 +20,9 @@ module OmniAuth
           :authorize_path => '/accounts/OAuthAuthorizeToken'
         }
 
-        options[:scope] ||= "http://www.google.com/m8/feeds"
-
+        google_contacts_auth = "http://www.google.com/m8/feeds"
+        options[:scope] << " #{google_contacts_auth}" unless options[:scope].include?(google_contacts_auth)
+        
         super(app, :google, consumer_key, consumer_secret, client_options, options)
       end
       


### PR DESCRIPTION
In the google strategy there is a hardcoded request to:
http://www.google.com/m8/feeds/contacts/default/full?max-results=1&alt=json

However, if the user specifies a scope of:
https://www.google.com/m8/feeds/

then Google will return an error since the scope requested was https while the request is using http.

I've changed the code to include the required feed.
