### PR TITLE
OAuth2 Strategy: Allow custom options to be sent to get_access_token in callback phase

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth2.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth2.rb
@@ -64,7 +64,7 @@ module OmniAuth
         end
         
         verifier = request.params['code']
-        @access_token = client.web_server.get_access_token(verifier, :redirect_uri => callback_url)
+        @access_token = client.web_server.get_access_token(verifier, {:redirect_uri => callback_url}.merge(options))
         
         if @access_token.expires? && @access_token.expires_in <= 0
           client.request(:post, client.access_token_url, { 
@@ -72,8 +72,8 @@ module OmniAuth
               'grant_type' => 'refresh_token', 
               'client_secret' => client_secret,
               'refresh_token' => @access_token.refresh_token 
-            })
-          @access_token = client.web_server.get_access_token(verifier, :redirect_uri => callback_url)
+            }.merge(options))
+          @access_token = client.web_server.get_access_token(verifier, {:redirect_uri => callback_url}.merge(options))
         end
         
         super


### PR DESCRIPTION
In the OAuth2 strategy I've added .merge(options) to the options hash that is passed to get_access_token and other requests in the callback phase. This matches the behaviour in the request phase. 

Passing the merged hash allows a subclass if the OAuth2 strategy to setup custom options that need to be sent in the token request. 

This change was needed to get an Instagram strategy to work because they need a custom option sent in the access token request. 
