### PR TITLE
Avoid destroying the omniauth.origin for strategies

### DIFF
--- a/oa-core/lib/omniauth/strategy.rb
+++ b/oa-core/lib/omniauth/strategy.rb
@@ -35,7 +35,7 @@ module OmniAuth
         if response = call_through_to_app
           response
         else
-          env['rack.session']['omniauth.origin'] = env['HTTP_REFERER']
+          env['rack.session']['omniauth.origin'] = env['HTTP_REFERER'] unless env['HTTP_REFERER'].end_with? request_path
           request_phase
         end
       elsif current_path == callback_path


### PR DESCRIPTION
Avoid destroying the omniauth.origin for strategies that require more than one request, like OpenID when it asks for the URL. 

Not sure if this is a correct fix though.

http://groups.google.com/group/omniauth/browse_thread/thread/1e4a3658f77807db
