### PR TITLE
Better support for Base URI

### DIFF
--- a/oa-core/lib/omniauth/strategy.rb
+++ b/oa-core/lib/omniauth/strategy.rb
@@ -108,7 +108,7 @@ module OmniAuth
     end
 
     def current_path
-      request.path.downcase.sub(/\/$/,'')
+      request.path_info.downcase.sub(/\/$/,'')
     end
 
     def query_string

--- a/oa-core/spec/omniauth/strategy_spec.rb
+++ b/oa-core/spec/omniauth/strategy_spec.rb
@@ -57,6 +57,25 @@ describe OmniAuth::Strategy do
         lambda{ strategy.call(make_env('/auth/test/callback', 'rack.session' => {'omniauth.origin' => 'http://example.com/origin'})) }.should raise_error("Callback Phase")
         strategy.last_env['omniauth.origin'].should == 'http://example.com/origin'
       end
+
+      context "with script_name" do
+        it 'should be set on the request phase, containing full path' do
+          env = {'HTTP_REFERER' => 'http://example.com/sub_uri/origin', 'SCRIPT_NAME' => '/sub_uri' }
+          lambda{ strategy.call(make_env('/auth/test', env)) }.should raise_error("Request Phase")
+          strategy.last_env['rack.session']['omniauth.origin'].should == 'http://example.com/sub_uri/origin'
+        end
+
+        it 'should be turned into an env variable on the callback phase, containing full path' do
+          env = {
+            'rack.session' => {'omniauth.origin' => 'http://example.com/sub_uri/origin'},
+            'SCRIPT_NAME' => '/sub_uri'
+          }
+
+          lambda{ strategy.call(make_env('/auth/test/callback', env)) }.should raise_error("Callback Phase")
+          strategy.last_env['omniauth.origin'].should == 'http://example.com/sub_uri/origin'
+        end
+
+      end
     end
 
     context 'default paths' do


### PR DESCRIPTION
If an application that uses Omniauth is mounted under a sub URI (such as passenger_base_uri /sub_uri; ), OmniAuth is unable to match either callback_path or request_path.

Also, when generating the callback_url, it should be considered.
