### PR TITLE
NetFlix Auth Hash Schema must contain a required ['user_info']['name'] entry

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/netflix.rb
+++ b/oa-oauth/lib/omniauth/strategies/netflix.rb
@@ -53,6 +53,7 @@ module OmniAuth
           'nickname' => user['nickname'],
           'first_name' => user['first_name'],
           'last_name' => user['last_name'],
+          'name' => "#{user['first_name']} #{user['last_name']}"
         }
       end
 


### PR DESCRIPTION
Thanks very much for your gem !!!

According to https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema
the ['user_info']['name'] is a required field, but NetFlix Strategy was not creating it.
Here I populate this field with first_name + blank + last_name

Regards,
David
