### PR TITLE
Document the type of UID

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -74,7 +74,7 @@ The hash in question will look something like this:
       }
     }
     
-The `user_info` hash will automatically be populated with as much information about the user as OmniAuth was able to pull from the given API or authentication provider.
+The `user_info` hash will automatically be populated with as much information about the user as OmniAuth was able to pull from the given API or authentication provider. Note that `uid` should be stored as an 8-byte integer (bigint) rather than a standard integer, since some providers (such as Facebook) have really long values for this field.
 
 ## Resources
 


### PR DESCRIPTION
UID needs to be a bigint to support newer facebook ids. This will fail for a typical integer column - raising in postgres and overflowing silently(!) for mysql.

I am not familiar with the other providers, perhaps this field should be a string? If so, this should be documented - the existing readme suggests that it should be an integer which is incorrect.
