### PR TITLE
Added support for force_login=true on twitter's /oauth/authenticate method

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth.rb
@@ -13,6 +13,7 @@ module OmniAuth
         super
         self.options[:open_timeout] ||= 30
         self.options[:read_timeout] ||= 30
+        self.options[:authorize_params] = options[:authorize_params] || {}
       end
 
       def consumer
@@ -32,9 +33,9 @@ module OmniAuth
         r = Rack::Response.new
 
         if request_token.callback_confirmed?
-          r.redirect(request_token.authorize_url)
+          r.redirect(request_token.authorize_url(options[:authorize_params]))
         else
-          r.redirect(request_token.authorize_url(:oauth_callback => callback_url))
+          r.redirect(request_token.authorize_url(options[:authorize_params].merge(:oauth_callback => callback_url)))
         end
 
         r.finish

--- a/oa-oauth/lib/omniauth/strategies/twitter.rb
+++ b/oa-oauth/lib/omniauth/strategies/twitter.rb
@@ -20,6 +20,7 @@ module OmniAuth
           :site => 'https://api.twitter.com'
         }
         
+        options[:authorize_params] = {:force_login => 'true'} if options.delete(:force_login) == true
         client_options[:authorize_path] = '/oauth/authenticate' unless options[:sign_in] == false
         super(app, :twitter, consumer_key, consumer_secret, client_options, options)
       end

--- a/oa-oauth/spec/omniauth/strategies/oauth_spec.rb
+++ b/oa-oauth/spec/omniauth/strategies/oauth_spec.rb
@@ -7,6 +7,7 @@ describe "OmniAuth::Strategies::OAuth" do
       use OmniAuth::Test::PhonySession
       use OmniAuth::Builder do
         provider :oauth, 'example.org', 'abc', 'def', :site => 'https://api.example.org'
+        provider :oauth, 'example.org_with_authorize_params', 'abc', 'def', { :site => 'https://api.example.org' }, :authorize_params => {:abc => 'def'}
       end
       run lambda { |env| [404, {'Content-Type' => 'text/plain'}, [env.key?('omniauth.auth').to_s]] }
     }.to_app
@@ -28,6 +29,12 @@ describe "OmniAuth::Strategies::OAuth" do
     it 'should redirect to authorize_url' do
       last_response.should be_redirect
       last_response.headers['Location'].should == 'https://api.example.org/oauth/authorize?oauth_token=yourtoken'
+    end
+
+    it 'should redirect to authorize_url with authorize_params when set' do
+      get '/auth/example.org_with_authorize_params'
+      last_response.should be_redirect
+      last_response.headers['Location'].should == 'https://api.example.org/oauth/authorize?abc=def&oauth_token=yourtoken'
     end
 
     it 'should set appropriate session variables' do

--- a/oa-oauth/spec/omniauth/strategies/twitter_spec.rb
+++ b/oa-oauth/spec/omniauth/strategies/twitter_spec.rb
@@ -7,6 +7,11 @@ describe OmniAuth::Strategies::Twitter do
     s = strategy_class.new(app, 'abc', 'def')
     s.consumer.options[:authorize_path].should == '/oauth/authenticate'
   end
+
+	it 'should set options[:authorize_params] to { :force_login => "true" } if :force_login is true' do
+		s = strategy_class.new(app, 'abc', 'def', :force_login => true)
+		s.options[:authorize_params].should == { :force_login => 'true' }
+	end
   
   it 'should use the authorize path if :sign_in is false' do
     s = strategy_class.new(app, 'abc', 'def', :sign_in => false)


### PR DESCRIPTION
I needed support for /oauth/authenticate?force_login=true with twitter, which is documented here: http://dev.twitter.com/doc/get/oauth/authenticate

This adds the option to arbitrarily add query string parameters to an oauth authorize URL as well as setting `options[:authorize_params] = {:force_login => 'true'}` when `:force_login => true` is passed to a twitter provider.
