### PR TITLE
Teambox oauth2 provider

### DIFF
--- a/oa-oauth/lib/omniauth/oauth.rb
+++ b/oa-oauth/lib/omniauth/oauth.rb
@@ -36,5 +36,6 @@ module OmniAuth
     autoload :Doit,               'omniauth/strategies/doit'
     autoload :Instapaper,         'omniauth/strategies/instapaper'
     autoload :TradeMe,            'omniauth/strategies/trade_me'
+    autoload :Teambox,            'omniauth/strategies/teambox'
   end
 end

--- a/oa-oauth/lib/omniauth/strategies/teambox.rb
+++ b/oa-oauth/lib/omniauth/strategies/teambox.rb
@@ -1,0 +1,49 @@
+require 'omniauth/oauth'
+require 'multi_json'
+
+module OmniAuth
+  module Strategies
+    class Teambox < OAuth2
+      def initialize(app, client_id = nil, client_secret = nil, options = {}, &block)
+        client_options = {
+          :site => "https://teambox.com/",
+          :authorize_path => "/oauth/authorize",
+          :access_token_path => "/oauth/token"
+        }
+        super(app, :teambox, client_id, client_secret, client_options, options, &block)
+      end
+      def request_phase
+        options[:scope] ||= "offline_access"
+        options[:response_type] ||= 'code'
+        super
+      end
+
+      def callback_phase
+        options[:grant_type] ||= 'authorization_code'
+        super
+      end
+
+      def user_data
+        @data ||= MultiJson.decode(@access_token.get("/api/1/account"))
+      end
+
+      def user_info
+        {
+          'nickname' => user_data['username'],
+          'name' => user_data['first_name'],
+          'image' => user_data['avatar_url'],
+          'urls' => {}
+        }
+      end
+
+      def auth_hash
+        OmniAuth::Utils.deep_merge(super, {
+          'uid' => user_data['id'],
+          'user_info' => user_info,
+          'extra' => {'user_hash' => user_data}
+        })
+      end
+    end
+  end
+end
+

--- a/oa-oauth/spec/omniauth/strategies/teambox_spec.rb
+++ b/oa-oauth/spec/omniauth/strategies/teambox_spec.rb
@@ -1,0 +1,5 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe OmniAuth::Strategies::Teambox do
+  it_should_behave_like "an oauth2 strategy"
+end


### PR DESCRIPTION
I added an oauth2 provider for Teambox OAuth. It's fairly simple and it works fine, I developed a couple of applications (yet to be opensourced) that use this fork of omniauth for authenticating through Teambox.
