### PR TITLE
update oauth2 version to >= 0.3.0

### DIFF
--- a/oa-oauth/oa-oauth.gemspec
+++ b/oa-oauth/oa-oauth.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency  'nokogiri',   '~> 1.4.2'
   gem.add_dependency  'oauth',      '~> 0.4.0'
   gem.add_dependency  'faraday',    '~> 0.6.1'
-  gem.add_dependency  'oauth2',     '~> 0.3.0'
+  gem.add_dependency  'oauth2',     '>= 0.3.0'
   
   eval File.read(File.join(File.dirname(__FILE__), '../development_dependencies.rb'))
 end


### PR DESCRIPTION
I needed the oauth2 update to 0.4.0 for some other deps, honestly lost track a bit at this point, but now this one needs to be relaxed as well. I did run the specs and they were all good, but I have to say I can't personally confirm both versions of the lib can work, just that I personally need to up it. If others think this is ok, then happy to see it brought in. 
