### PR TITLE
fix LDAP blank password error

### DIFF
--- a/oa-enterprise/lib/omniauth/strategies/ldap/adaptor.rb
+++ b/oa-enterprise/lib/omniauth/strategies/ldap/adaptor.rb
@@ -247,6 +247,7 @@ module OmniAuth
             :password => (options[:password]||@password).to_s,
           }
           begin
+            raise AuthenticationError if args[:password] == ""
             execute(:bind, args)
             true
           rescue Exception


### PR DESCRIPTION
When LDAP is being used with a `bind_dn` and a `password` provided in the configuration; a user can simply enter a valid username and leave the password field blank and still log in. This patch corrects that behavior and throws and `AuthenticationError` when the user does not provide a password.
