### PR TITLE
Google oauth, default scope

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/google.rb
+++ b/oa-oauth/lib/omniauth/strategies/google.rb
@@ -20,9 +20,9 @@ module OmniAuth
           :authorize_path => '/accounts/OAuthAuthorizeToken'
         }
 
-        google_contacts_auth = "http://www.google.com/m8/feeds"
+        google_contacts_auth = "www.google.com/m8/feeds"
         options[:scope] ||= google_contacts_auth
-        options[:scope] << " #{google_contacts_auth}" unless options[:scope].include?(google_contacts_auth)
+        options[:scope] << " http://#{google_contacts_auth}" unless options[:scope] =~ %r[http[s]?:\/\/#{google_contacts_auth}]
 
         super(app, :google, consumer_key, consumer_secret, client_options, options)
       end


### PR DESCRIPTION
Google scope are provided in url format, like this:

```
'https://docs.google.com/feeds/ https://www.google.com/calendar/feeds/ https://www.google.com/m8/feeds'
```

For most of them, http and https format are valid but the actual implementation only check for http.

If you set options[:scope] to "http__s__://www.google.com/m8/feeds", the scope the final scope will be

```
"https://www.google.com/m8/feeds http://www.google.com/m8/feeds"
```

In that case, 'Google Contacts' will appear duplicated in the list of  resources to authorize on the google authorization page!

http://cl.ly/1W3G0F3y3Y263t381u3e
