### PR TITLE
vkontakte empty response handling

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/vkontakte.rb
+++ b/oa-oauth/lib/omniauth/strategies/vkontakte.rb
@@ -36,10 +36,10 @@ module OmniAuth
 
         # we need these 2 additional requests since vkontakte returns only ids of the City and Country
         # http://vkontakte.ru/developers.php?o=-17680044&p=getCities
-        @city ||= MultiJson.decode(@access_token.get("https://api.vkontakte.ru/method/getCities?cids=#{@data['city']}&access_token=#{@access_token.token}"))['response'][0]['name']
+        @city ||= MultiJson.decode(@access_token.get("https://api.vkontakte.ru/method/getCities?cids=#{@data['city']}&access_token=#{@access_token.token}"))['response'].try(:[], 0).try(:[], 'name')
 
         # http://vkontakte.ru/developers.php?o=-17680044&p=getCountries
-        @country ||= MultiJson.decode(@access_token.get("https://api.vkontakte.ru/method/getCountries?cids=#{@data['country']}&access_token=#{@access_token}"))['response'][0]['name']
+        @country ||= MultiJson.decode(@access_token.get("https://api.vkontakte.ru/method/getCountries?cids=#{@data['country']}&access_token=#{@access_token}"))['response'].try(:[], 0).try(:[], 'name')
       end
 
     def request_phase


### PR DESCRIPTION
Vkontakte sometimes respond with nothing to getCities and getCounties request. For example: https://api.vkontakte.ru/method/getCities?cids=0

Sometimes getProfiles returns city as 0 field, possibly when user hides this information from public profile.
