### PR TITLE
Fixed parsing of LinkedIn profiles with no member/custom urls

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/linked_in.rb
+++ b/oa-oauth/lib/omniauth/strategies/linked_in.rb
@@ -41,8 +41,10 @@ module OmniAuth
           'public_profile_url' => person['public_profile_url']
         }
         hash['urls']={}
-        person['member_url_resources']['member_url'].each do |url|
-          hash['urls']["#{url['name']}"]=url['url']
+        unless person['member_url_resources']['member_url'].blank?
+          person['member_url_resources']['member_url'].each do |url|
+            hash['urls']["#{url['name']}"]=url['url']
+          end
         end
         hash['urls']['LinkedIn'] = person['public_profile_url']
         hash['name'] = "#{hash['first_name']} #{hash['last_name']}"


### PR DESCRIPTION
LinkedIn profiles without member urls dont have ['member_url'] nested hash inside person['member_url_resources']
