### PR TITLE
Catch Timeout exceptions from OAuth2 (Facebook)

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth2.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth2.rb
@@ -80,6 +80,8 @@ module OmniAuth
         fail!(:invalid_credentials, e)
       rescue ::MultiJson::DecodeError => e
         fail!(:invalid_response, e)
+      rescue ::Timeout::Error, ::Errno::ETIMEDOUT => e
+        fail!(:timeout, e)
       end
 
       def build_access_token


### PR DESCRIPTION
I've run into a few of these in production usage
