### PR TITLE
credentials.merge(...) without exclamation mark doesn't put values into credentials hash

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth2.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth2.rb
@@ -91,7 +91,7 @@ module OmniAuth
 
       def auth_hash
         credentials = {'token' => @access_token.token}
-        credentials.merge('refresh_token' => @access_token.refresh_token) if @access_token.expires?
+        credentials.merge!('refresh_token' => @access_token.refresh_token) if @access_token.expires?
 
         OmniAuth::Utils.deep_merge(super, {'credentials' => credentials})
       end


### PR DESCRIPTION
credentials.merge(...) without exclamation mark doesn't put values into credentials hash instead it returns a new 'merged' hash which is not assigned to anything and 'refresh_token' value never gets added to credentials hash.

With exclamation mark value is added directly to credentials hash (and everybody is happy!)
