### PR TITLE
Linked In Fix - User with No URLS or exactly one URL.

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/linked_in.rb
+++ b/oa-oauth/lib/omniauth/strategies/linked_in.rb
@@ -40,10 +40,13 @@ module OmniAuth
           'description' => person['headline'],
           'public_profile_url' => person['public_profile_url']
         }
-        hash['urls']={}
-        person['member_url_resources']['member_url'].each do |url|
-          hash['urls']["#{url['name']}"]=url['url']
-        end
+        hash['urls']={}                
+        member_urls = person['member_url_resources']['member_url']
+        if (!member_urls.nil?) and (!member_urls.empty?)
+          [member_urls].flatten.each do |url|
+            hash['urls']["#{url['name']}"]=url['url']
+          end
+        end    
         hash['urls']['LinkedIn'] = person['public_profile_url']
         hash['name'] = "#{hash['first_name']} #{hash['last_name']}"
         hash


### PR DESCRIPTION
Fixes an issue with a user having exactly one URL - .each was iterating through
the hash keys/values and raising an exception.

Also supports members with no URLs.
