### PR TITLE
Facebook Username Fix

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/facebook.rb
+++ b/oa-oauth/lib/omniauth/strategies/facebook.rb
@@ -45,7 +45,7 @@ module OmniAuth
 
       def user_info
         {
-          'nickname' => user_data["link"].split('/').last,
+          'nickname' => user_data["username"],
           'email' => (user_data["email"] if user_data["email"]),
           'first_name' => user_data["first_name"],
           'last_name' => user_data["last_name"],


### PR DESCRIPTION
If a user hasn't defined their nicename omniauth pulls in "profile.php?id=XXXXX". 
I switched the nickname to pull from facebook username instead of the end of the user's profile url.

Credit :http://stackoverflow.com/questions/5765987/omniauth-facebook-authentication-nickname-returning-profile-phpid
