### PR TITLE
Vkontakte strategy: Fix user_info hash parameter 'firstname' to 'first_name' like many other 

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/vkontakte.rb
+++ b/oa-oauth/lib/omniauth/strategies/vkontakte.rb
@@ -51,7 +51,7 @@ module OmniAuth
 
     def user_info
       {
-        'firstname' => @data['first_name'],
+        'first_name' => @data['first_name'],
         'last_name' => @data['last_name'],
         'name' => "#{@data['first_name']} #{@data['last_name']}",
         'nickname' => @data['nickname'],


### PR DESCRIPTION
Fix user_info hash parameter 'firstname' to 'first_name' like many other providers have.
