### PR TITLE
Parse CAS extra attributes

### DIFF
--- a/oa-enterprise/lib/omniauth/strategies/cas/service_ticket_validator.rb
+++ b/oa-enterprise/lib/omniauth/strategies/cas/service_ticket_validator.rb
@@ -45,10 +45,10 @@ module OmniAuth
                    e.name == 'proxies'
               # There are no child elements
               if e.element_children.count == 0
-                hash[e.name] = e.content
+                hash[e.name.sub(/^cas:/, '')] = e.content
               elsif e.element_children.count				
-                hash[e.name] = [] if hash[e.name].nil?
-                hash[e.name].push parse_user_info e
+                hash[e.name.sub(/^cas:/, '')] = [] if hash[e.name.sub(/^cas:/, '')].nil?
+                hash[e.name.sub(/^cas:/, '')].push parse_user_info e
               end
             end
           end


### PR DESCRIPTION
Changed parse_user_info method in order to correctly parse user attributes.

I've written a patch for the CAS Strategy. It's now possible to correctly receive extra attributes from CAS (as implemented by CAS 2.0, RubyCAS Server, ...). 

An example hash (depending on the amount of extra attributes) could look like this:

```
provider: cas
uid: fbkr47
extra: 
  attributes: 
  - mail: value
    attribute: 
    - name: mail
      value: value
    - name: username
      value: value
    - name: userClass
      value: S
    - name: department
      value: "someValue"
    - name: displayName
      value: John Smith
    - name: surnames
      value: Smith
    - name: firstnames
      value: John
    username: fbkr47
    userClass: S
    department: "someValue"
    displayName: John Smith
    surnames: Smith
    firstnames: John
```

Cheers,
Fabian
