### PR TITLE
Modified LDAP provider

### DIFF
--- a/oa-enterprise/lib/omniauth/strategies/ldap/adaptor.rb
+++ b/oa-enterprise/lib/omniauth/strategies/ldap/adaptor.rb
@@ -128,13 +128,11 @@ module OmniAuth
 
         def search(options={}, &block)
           base = options[:base]
-          filter = options[:filter]
-          limit = options[:limit]
+          filter = Net::LDAP::Filter.eq('objectClass','*') & options[:filter]
 
           args = {
             :base => @base,
-            :filter => filter,
-            :size => limit
+            :filter => filter
           }
 
           attributes = {}


### PR DESCRIPTION
Modified directory search to include the objectClass=\* filter. Without this filter, I have not been able to perform a successful auth on the Oracle's OID.
