### PR TITLE
Fix github oauth urls

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/github.rb
+++ b/oa-oauth/lib/omniauth/strategies/github.rb
@@ -14,7 +14,7 @@ module OmniAuth
         client_options = {
           :site => 'https://github.com/',
           :authorize_url => '/login/oauth/authorize',
-          :access_token_url => '/login/oauth/access_token'
+          :token_url => '/login/oauth/access_token'
         }
 
         super(app, :github, client_id, client_secret, client_options, options, &block)


### PR DESCRIPTION
Re: https://github.com/intridea/oauth2/commit/12dfd832ea2a2be10b0a0be0cdb50f310bf226f3

Should all of these strategies be updated...? It looks like it to me. 
