### PR TITLE
oa-identity is passing provider name to hash as a symbol instead of a string

### DIFF
--- a/oa-identity/lib/omniauth/strategies/identity.rb
+++ b/oa-identity/lib/omniauth/strategies/identity.rb
@@ -70,7 +70,7 @@ module OmniAuth
 
       def auth_hash 
         {
-          'provider' => name,
+          'provider' => name.to_s,
           'uid' => identity.uid,
           'user_info' => identity.user_info
         }


### PR DESCRIPTION
I changed the auto hash to accept =>name.to_s instead of  =>name
