### PR TITLE
Allow :scope => "basic" for no extended permissions

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/facebook.rb
+++ b/oa-oauth/lib/omniauth/strategies/facebook.rb
@@ -23,6 +23,8 @@ module OmniAuth
 
       def request_phase
         options[:scope] ||= "email,offline_access"
+        options.delete(:scope) if options[:scope] == "basic"
+        
         super
       end
 


### PR DESCRIPTION
The Facebook authentication doc states "There is a strong inverse correlation between the number of permissions your app requests and the number of users that will allow those permissions." So I don't want to ask for any permissions I don't need; right now, I don't need any extended permissions at all.  Unfortunately, the Facebook strategy says:

```
    options[:scope] ||= "email,offline_access"
```

which means there's no way to have a nil scope.  This patch teaches oauth that if you declare :scope => "basic", it should delete the scope option altogether.
