### PR TITLE
1.0 beta - Relax dependency on addressable

### DIFF
--- a/oa-enterprise/oa-enterprise.gemspec
+++ b/oa-enterprise/oa-enterprise.gemspec
@@ -2,7 +2,7 @@
 require File.expand_path('../lib/omniauth/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.add_runtime_dependency 'addressable', '2.2.4'
+  gem.add_runtime_dependency 'addressable', '~> 2.2.4'
   gem.add_runtime_dependency 'nokogiri', '~> 1.4.2'
   gem.add_runtime_dependency 'net-ldap', '~> 0.2.2'
   gem.add_runtime_dependency 'oa-core', OmniAuth::Version::STRING


### PR DESCRIPTION
The oa-enterprise gemspec declares a dependency on `addressable 2.2.4`, but 2.2.6 is already out and used by some gems. This relaxes the dependency to `addressable ~> 2.2.4`.
