### PR TITLE
Fixed - Invalid response when linked in user has no public profile url

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth/linked_in.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth/linked_in.rb
@@ -29,7 +29,7 @@ module OmniAuth
           'id' => person['id'],
           'first_name' => person['first_name'],
           'last_name' => person['last_name'],
-          'nickname' => person['public_profile_url'].split('/').last,
+          'nickname' => person['public_profile_url'].to_s.split('/').last,
           'location' => person['location']['name'],
           'image' => person['picture_url'],
           'description' => person['headline'],


### PR DESCRIPTION
Hi,

We ran into a small problem using linked in as an omniauth provider...

The code to parse the response from linked in assumes that it can retrieve the nickname from the user's public profile url. This causes an exception when the user doesn't have a public profile url because the code tries to split nil. Fixed by simply calling to_s before the split.

Mark
