### PR TITLE
twitter strategy tweak

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth/twitter.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth/twitter.rb
@@ -19,7 +19,7 @@ module OmniAuth
         }
         options[:authorize_params] = {:force_login => 'true'} if options.delete(:force_login) == true
         client_options[:authorize_path] = '/oauth/authenticate' unless options[:sign_in] == false
-        super(app, :twitter, consumer_key, consumer_secret, client_options, options)
+        super(app, options[:name] || :twitter, consumer_key, consumer_secret, client_options, options)
       end
 
       def auth_hash


### PR DESCRIPTION
for your consideration ... a small fix for the twitter strategy so that the name option is honoured and we can authenticate for multiple twitter application key/secret pairs in a single application (like we already can for openid, cas, etc.)

cheers.

--Brent
