### PR TITLE
catch bad gateway on oauth request token fetch

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth.rb
@@ -40,6 +40,8 @@ module OmniAuth
 
       rescue ::Timeout::Error => e
         fail!(:timeout, e)
+      rescue ::Net::HTTPFatalError => e
+        fail!(:service_unavailable, e)
       end
 
       def callback_phase


### PR DESCRIPTION
sometimes when you're fetching a token, the provider yields a Bad Gateway 502. This catches Net::HTTPFatalError and fails with :service_unavailable.

smooches.
@ngauthier
