### PR TITLE
One line addition to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ OmniAuth currently supports the following external providers:
   * Vimeo (credit: [jamiew](https://github.com/jamiew))
   * Vkontakte (credit: [german](https://github.com/german))
   * WePay (credit: [ryanwood](https://github.com/ryanwood))
+  * Yahoo (credit: [mpd](https://github.com/mpd))
   * Yammer (credit: [kltcalamay](https://github.com/kltcalamay))
   * YouTube (credit: [jamiew](https://github.com/jamiew))
 * CAS (Central Authentication Service) (credit: [jamesarosen](https://github.com/jamesarosen))


### PR DESCRIPTION
I'm using OmniAuth with the Yahoo API. The README didn't have it listed, but there is a strategy for Yahoo and it's working for me.
