### PR TITLE
remove the unnecessary line of requiring 'evernote' which will cause fail

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth/evernote.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth/evernote.rb
@@ -1,6 +1,5 @@
 require 'omniauth/oauth'
 require 'multi_json'
-require 'evernote'
 
 module OmniAuth
   module Strategies


### PR DESCRIPTION
remove the unnecessary line of requiring 'evernote' which will cause failure in loading it.

I opened an issue for it:

https://github.com/intridea/omniauth/issues/398
