### PR TITLE
Fixed a typo.. crendentails should be credentials on the omniauth hash

### DIFF
--- a/oa-openid/lib/omniauth/strategies/google_hybrid.rb
+++ b/oa-openid/lib/omniauth/strategies/google_hybrid.rb
@@ -42,7 +42,7 @@ module OmniAuth
         OmniAuth::Utils.deep_merge(super(), {
           'uid' => @openid_response.display_identifier,
           'user_info' => user_info(@openid_response),
-          'credentails' => {
+          'credentials' => {
             'scope' => @options[:scope], 
             'token' => @access_token.token,
             'secret' => @access_token.secret


### PR DESCRIPTION
I made a pretty crappy typo in the hash that omniauth returns. Instead of 'credentials' it returns 'credentails', sorry.
