### PR TITLE
Some fixes to the Vkontakte strategy

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth2/vkontakte.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth2/vkontakte.rb
@@ -66,7 +66,9 @@ module OmniAuth
         token = super
         # indicates that `offline` permission was granted, no need to the token refresh
         if token.expires_in == 0
-          ::OAuth2::AccessToken.new(token.client, token.token)
+          ::OAuth2::AccessToken.new(token.client, token.token,
+            token.params.reject{|k,_| [:refresh_token, :expires_in, :expires_at, :expires].include? k.to_sym}
+          )
         else
           token
         end


### PR DESCRIPTION
VK returns expired_in = 0 when the long-living access_token was requested by setting 'offline' scope.
This leads to the instant token refreshing that fails because refresh_token is empty anyway.
