### PR TITLE
Maintain query string parameters in test mode.

### DIFF
--- a/oa-core/lib/omniauth/strategy.rb
+++ b/oa-core/lib/omniauth/strategy.rb
@@ -95,7 +95,7 @@ module OmniAuth
       elsif env['HTTP_REFERER'] && !env['HTTP_REFERER'].match(/#{request_path}$/)
         @env['rack.session']['omniauth.origin'] = env['HTTP_REFERER']
       end
-      redirect(script_name + callback_path)
+      redirect(script_name + callback_path + query_string)
     end
 
     def mock_callback_call

--- a/oa-core/spec/omniauth/strategy_spec.rb
+++ b/oa-core/spec/omniauth/strategy_spec.rb
@@ -267,6 +267,11 @@ describe OmniAuth::Strategy do
         strategy.call(make_env('/AUTH/TeSt/CaLlBAck')).should == strategy.call(make_env('/auth/test/callback'))
       end
 
+      it 'should maintain query string parameters' do
+        response = strategy.call(make_env('/auth/test', 'QUERY_STRING' => 'cheese=stilton'))
+        response[1]['Location'].should == '/auth/test/callback?cheese=stilton'
+      end
+
       it 'should not short circuit requests outside of authentication' do
         strategy.call(make_env('/')).should == app.call(make_env('/'))
       end


### PR DESCRIPTION
See this issue: https://github.com/intridea/omniauth/issues/359

I've added a spec and a fix for this.

I thought it made sense to just add "+ query_string" rather than use callback_url, because, as the ticket says, this can cause problems if test domains are setup incorrectly.

This only affects test mode as the change is to the +mock_request_call+ method.
