### PR TITLE
Changed the Hyves OAuth strategy to allow options to be set

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth/hyves.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth/hyves.rb
@@ -5,13 +5,19 @@ module OmniAuth
   module Strategies
     class Hyves < OmniAuth::Strategies::OAuth
       def initialize(app, consumer_key=nil, consumer_secret=nil, options={}, &block)
+        options = {
+          :methods => 'users.get,friends.get,wwws.create',
+          :expirationtype => 'default'
+        }.merge(options)
+
         client_options = {
           :authorize_path => 'http://www.hyves.nl/api/authorize',
           :access_token_path => access_token_path,
           :http_method => :get,
-          :request_token_path => request_token_path,
+          :request_token_path => request_token_path(options),
           :scheme => :header,
         }
+
         super(app, :hyves, consumer_key, consumer_secret, client_options, options, &block)
       end
 
@@ -37,8 +43,10 @@ module OmniAuth
         rsp['user'].first
       end
 
-      def request_token_path
-        "http://data.hyves-api.nl/?#{request_token_options}&#{default_options}"
+      def request_token_path(options)
+        options['ha_method'] = 'auth.requesttoken'
+        options['strict_oauth_spec_response'] = true
+        "http://data.hyves-api.nl/?#{to_params(options)}&#{default_options}"
       end
 
       def access_token_path
@@ -47,10 +55,6 @@ module OmniAuth
 
       def default_options
         to_params({:ha_version => '2.0', :ha_format => 'json', :ha_fancylayout => false})
-      end
-
-      def request_token_options
-        to_params({:methods => 'users.get,friends.get,wwws.create', :ha_method => 'auth.requesttoken', :strict_oauth_spec_response => true})
       end
 
       def access_token_options


### PR DESCRIPTION
Changed the Hyves OAuth strategy to allow options to be set for the 'request token' stage.

The previous strategy just selected a few default methods and used the default expiration type, which is 6 hours. This made the strategy less suitable if you want to use the tokens for more than just authentication :).

By adding options you can customize the methods (scope) and duration of the authorization:

``` ruby
:hyves, 'token', 'secret', :methods => 'users.get,friends.get', :expirationtype => 'infinite'
```
