### PR TITLE
(Dropbox oauth strategy) parse user uid and email into user_info hash

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth/dropbox.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth/dropbox.rb
@@ -31,6 +31,8 @@ module OmniAuth
       def user_info
         {
           'name' => user_data['display_name'],
+          'uid' => user_data['uid'],
+          'email' => user_data['email']
         }
       end
     end


### PR DESCRIPTION
in Dropbox strategy parse user uid and email into user_info hash so that omniauth "client" code could access those in a usual manner (without hand parsing access_token.request)
