### PR TITLE
Update Instagram strategy to be compatible with new OAuth2 gem

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth2/instagram.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth2/instagram.rb
@@ -42,6 +42,7 @@ module OmniAuth
       end
 
       def user_data
+        @access_token.options.merge!({:param_name => 'access_token', :mode => :query})
         @data ||= MultiJson.decode(@access_token.get('/v1/users/self'))
       end
 

--- a/oa-oauth/spec/omniauth/strategies/oauth2/instagram_spec.rb
+++ b/oa-oauth/spec/omniauth/strategies/oauth2/instagram_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe OmniAuth::Strategies::GitHub do
+  it_should_behave_like "an oauth2 strategy"
+end


### PR DESCRIPTION
I've updated the Instagram strategy to specify what mode it should be, as well as what the access token param is to be compatible with the new version of the OAuth2 gem
