### PR TITLE
Return :service_unavailable if SSL fails

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth.rb
@@ -62,6 +62,8 @@ module OmniAuth
         fail!(:timeout, e)
       rescue ::Net::HTTPFatalError => e
         fail!(:service_unavailable, e)
+      rescue ::OpenSSL::SSL::SSLError => e
+        fail!(:service_unavailable, e)
       rescue ::OAuth::Unauthorized => e
         fail!(:invalid_credentials, e)
       rescue ::NoMethodError, ::MultiJson::DecodeError => e

--- a/oa-oauth/spec/omniauth/strategies/oauth/oauth_spec.rb
+++ b/oa-oauth/spec/omniauth/strategies/oauth/oauth_spec.rb
@@ -88,6 +88,19 @@ describe "OmniAuth::Strategies::OAuth" do
         last_request.env['omniauth.error.type'] = :service_unavailable
       end
     end
+
+    context "SSL failure" do
+      before do
+        stub_request(:post, 'https://api.example.org/oauth/access_token').
+           to_raise(::OpenSSL::SSL::SSLError.new("SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed"))
+        get '/auth/example.org/callback', {:oauth_verifier => 'dudeman'}, {'rack.session' => {'oauth' => {"example.org" => {'callback_confirmed' => true, 'request_token' => 'yourtoken', 'request_secret' => 'yoursecret'}}}}
+      end
+
+      it 'should call fail! with :service_unavailable' do
+        last_request.env['omniauth.error'].should be_kind_of(::OpenSSL::SSL::SSLError)
+        last_request.env['omniauth.error.type'] = :service_unavailable
+      end
+    end
   end
 
   describe '/auth/{name}/callback with expired session' do


### PR DESCRIPTION
Hi guys,

Just ran into an SSL error with Twitter today during the callback phase. This pull request catches SSL errors and returns :service_unavailable.
