### PR TITLE
Removed repetition of word 'that' from description 

### DIFF
--- a/omniauth.gemspec
+++ b/omniauth.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |gem|
     gem.add_dependency subgem, OmniAuth::Version::STRING
   end
   gem.authors = ['Michael Bleigh', 'Erik Michaels-Ober']
-  gem.description = %q{OmniAuth is an authentication framework that that separates the concept of authentiation from the concept of identity, providing simple hooks for any application to have one or multiple authentication providers for a user.}
+  gem.description = %q{OmniAuth is an authentication framework that separates the concept of authentiation from the concept of identity, providing simple hooks for any application to have one or multiple authentication providers for a user.}
   gem.email = ['michael@intridea.com', 'sferik@gmail.com']
   gem.files = Dir.glob("lib/**/*") + %w(README.md LICENSE.md)
   gem.homepage = 'http://github.com/intridea/omniauth'


### PR DESCRIPTION
There's repetition of 'that' word in 'omniauth.gemspec' file. I'm packaging this gem in debian, and 'lintian' gives Warning about this.
