### PR TITLE
Small typo fixes

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth/t163.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth/t163.rb
@@ -42,7 +42,7 @@ module OmniAuth
           'location' => user_hash['location'],
           'image' => user_hash['profile_image_url'],
           'description' => user_hash['description'],
-          'email' => user_hash['email']
+          'email' => user_hash['email'],
           'urls' => {
             'T163' => 'http://t.163.com',
           },

--- a/oa-oauth/spec/omniauth/strategies/oauth2/mailchimp_spec.rb
+++ b/oa-oauth/spec/omniauth/strategies/oauth2/mailchimp_spec.rb
@@ -1,6 +1,6 @@
 # oa-oauth/spec/omniauth/strategies/rdio_spec.rb
-require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../../../../spec_helper', __FILE__)
 
 describe OmniAuth::Strategies::Mailchimp do
-  it_should_behave_like "an oauth strategy"
+  it_should_behave_like "an oauth2 strategy"
 end


### PR DESCRIPTION
Mailchimp is an oauth2, not oauth strategy.
Added comma in hash literal, so specs are passing on Ruby 1.8 now.
