### PR TITLE
Added OAuth2 Strategy for AngelList

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ OmniAuth currently supports the following external providers:
 
 * via OAuth (OAuth 1.0, OAuth 2, and xAuth)
   * 37signals ID (credit: [mbleigh](https://github.com/mbleigh))
+  * AngelList (credit: [joshuaxls](https://github.com/joshuaxls))
   * Bit.ly (credit: [philnash](https://github.com/philnash))
   * Blogger (credit: [dsueiro-backing](https://github.com/dsueiro-backing))
   * Cobot (credit: [kamal](https://github.com/kamal))

--- a/oa-oauth/lib/omniauth/oauth.rb
+++ b/oa-oauth/lib/omniauth/oauth.rb
@@ -40,6 +40,7 @@ module OmniAuth
     autoload :YouTube,            'omniauth/strategies/oauth/you_tube'
 
     autoload :OAuth2,             'omniauth/strategies/oauth2'
+    autoload :AngelList,          'omniauth/strategies/oauth2/angellist'
     autoload :Bitly,              'omniauth/strategies/oauth2/bitly'
     autoload :Cobot,              'omniauth/strategies/oauth2/cobot'
     autoload :Dailymile,          'omniauth/strategies/oauth2/dailymile'

--- a/oa-oauth/lib/omniauth/strategies/oauth2/angellist.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth2/angellist.rb
@@ -1,0 +1,57 @@
+require 'omniauth/oauth'
+require 'multi_json'
+
+module OmniAuth
+  module Strategies
+    # Authenticate to AngelList utilizing OAuth 2.0 and retrieve
+    # basic user information.
+    #
+    # @example Basic Usage
+    #     use OmniAuth::Strategies::AngelList, 'API Key', 'Secret Key'
+    class AngelList < OmniAuth::Strategies::OAuth2
+      # @param [Rack Application] app standard middleware application parameter
+      # @param [String] client_id the application id as [registered on AngelList](http://angel.co/api/oauth/faq)
+      # @param [String] client_secret the application secret as [registered on AngelList](http://bit.ly/api/oauth/faq )
+      def initialize(app, client_id=nil, client_secret=nil, options={}, &block)
+        client_options = {
+          :site => 'https://api.angel.co/',
+          :authorize_url => 'https://angel.co/api/oauth/authorize',
+          :token_url => 'https://angel.co/api/oauth/token'
+        }
+
+        super(app, :angellist, client_id, client_secret, client_options, options, &block)
+      end
+
+      def auth_hash
+        OmniAuth::Utils.deep_merge(
+          super, {
+            'uid' => user_data['id'],
+            'user_info' => user_info,
+            'extra' => {
+              'user_hash' => user_data,
+            }
+          }
+        )
+      end
+
+      def user_info
+        {
+          'name' => user_data['name'],
+          'bio' => user_data['bio'],
+          'image' => user_data['image'],
+          'urls' => {
+            'AngelList' => user_data['angellist_url'],
+            'Website' => user_data['online_bio_url']
+          },
+        }
+      end
+
+      def user_data
+        @data ||= begin
+          @access_token.options[:mode] = :query
+          @access_token.get('/1/me').parsed
+        end
+      end
+    end
+  end
+end

--- a/oa-oauth/spec/omniauth/strategies/oauth2/angellist_spec.rb
+++ b/oa-oauth/spec/omniauth/strategies/oauth2/angellist_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe OmniAuth::Strategies::AngelList do
+  it_should_behave_like "an oauth2 strategy"
+end


### PR DESCRIPTION
We're in the process of launching an API at AngelList and would love to be included in OmniAuth. We've used OmniAuth from the beginning for our own OAuth consumer needs—guys, thanks a bunch for your work!

http://angel.co/api/oauth/faq
