### PR TITLE
Add additional fields to Salesforce strategy.

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth2/salesforce.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth2/salesforce.rb
@@ -18,7 +18,10 @@ module OmniAuth
           super, {
             'uid' => @access_token['id'],
             'credentials' => {
+              'issued_at' => @access_token['issued_at'],
+              'refresh_token' => @access_token.refresh_token,
               'instance_url' => @access_token['instance_url'],
+              'signature' => @access_token['signature'],
             },
             'extra' => {
               'user_hash' => data,


### PR DESCRIPTION
Salesforce provides additional fields namely issued_at & signature that can be returned. 

access_token which is returned after authorization is always perishable. But in line https://github.com/intridea/omniauth/blob/master/oa-oauth/lib/omniauth/strategies/oauth2.rb#L87 

``` ruby
... if @access_token.expires?
```

always returns false causing refresh_token never to be set for Salesforce strategy.

To summarise issued_at & signature definitely needs to be added.

There may be perhaps a better way to indicate fetching of refresh_token rather the brute force approach taken in the pull request.
