### PR TITLE
Fixes a bug with empty open_id identifier from form field fixed

### DIFF
--- a/oa-openid/lib/omniauth/strategies/open_id.rb
+++ b/oa-openid/lib/omniauth/strategies/open_id.rb
@@ -56,9 +56,11 @@ module OmniAuth
       end
 
       def identifier
-        options[:identifier] || request[IDENTIFIER_URL_PARAMETER]
+        i = options[:identifier] || request[IDENTIFIER_URL_PARAMETER]
+        i = nil if i == ''
+        i
       end
-
+      
       def request_phase
         identifier ? start : get_identifier
       end


### PR DESCRIPTION
Then leaving the open_id form field empty and clicking the 'Connect' button an exception is thrown. 
Also reported here: http://groups.google.com/group/omniauth/browse_thread/thread/559356fb2f9967e0?fwc=2

My stack trace:

ruby-openid (2.1.8) lib/openid/consumer/discovery.rb:467:in `discover_uri'
ruby-openid (2.1.8) lib/openid/consumer/discovery.rb:494:in`discover'
oa-openid (0.2.6) lib/omniauth/openid/gapps.rb:10:in `discover'
ruby-openid (2.1.8) lib/openid/consumer.rb:333:in`discover'
ruby-openid (2.1.8) lib/openid/consumer/discovery_manager.rb:51:in `get_next_service'
ruby-openid (2.1.8) lib/openid/consumer.rb:222:in`begin'
rack-openid (1.3.1) lib/rack/openid.rb:123:in `begin_authentication'
rack-openid (1.3.1) lib/rack/openid.rb:102:in`call'
oa-openid (0.2.6) lib/omniauth/strategies/open_id.rb:71:in `start'
oa-openid (0.2.6) lib/omniauth/strategies/open_id.rb:66:in`request_phase'
oa-core (0.2.6) lib/omniauth/strategy.rb:58:in `request_call'
oa-core (0.2.6) lib/omniauth/strategy.rb:41:in`call!'
oa-core (0.2.6) lib/omniauth/strategy.rb:30:in `call'
oa-core (0.2.6) lib/omniauth/strategy.rb:44:in`call!'
oa-core (0.2.6) lib/omniauth/strategy.rb:30:in `call'
oa-core (0.2.6) lib/omniauth/strategy.rb:44:in`call!'
oa-core (0.2.6) lib/omniauth/strategy.rb:30:in `call'
hoptoad_notifier (2.4.9) lib/hoptoad_notifier/rack.rb:27:in`call'
newrelic_rpm (3.0.1) lib/new_relic/rack/browser_monitoring.rb:18:in `call'
newrelic_rpm (3.0.1) lib/new_relic/rack/developer_mode.rb:24:in`call'
app/middlewares/embedded_redirect.rb:39:in `call'
app/middlewares/query_string_beautifier.rb:45:in`call'
sass (3.1.7) lib/sass/plugin/rack.rb:54:in `call'
warden (1.0.5) lib/warden/manager.rb:35:in`block in call'
warden (1.0.5) lib/warden/manager.rb:34:in `catch'
warden (1.0.5) lib/warden/manager.rb:34:in`call'
app/middlewares/url_shortener.rb:32:in `call'
actionpack (3.0.10) lib/action_dispatch/middleware/best_standards_support.rb:17:in`call'
actionpack (3.0.10) lib/action_dispatch/middleware/head.rb:14:in `call'
rack (1.2.3) lib/rack/methodoverride.rb:24:in`call'
actionpack (3.0.10) lib/action_dispatch/middleware/params_parser.rb:21:in `call'
actionpack (3.0.10) lib/action_dispatch/middleware/flash.rb:182:in`call'
actionpack (3.0.10) lib/action_dispatch/middleware/session/abstract_store.rb:149:in `call'
actionpack (3.0.10) lib/action_dispatch/middleware/cookies.rb:302:in`call'
activerecord (3.0.10) lib/active_record/query_cache.rb:32:in `block in call'
activerecord (3.0.10) lib/active_record/connection_adapters/abstract/query_cache.rb:28:in`cache'
activerecord (3.0.10) lib/active_record/query_cache.rb:12:in `cache'
activerecord (3.0.10) lib/active_record/query_cache.rb:31:in`call'
activerecord (3.0.10) lib/active_record/connection_adapters/abstract/connection_pool.rb:354:in `call'
actionpack (3.0.10) lib/action_dispatch/middleware/callbacks.rb:46:in`block in call'
activesupport (3.0.10) lib/active_support/callbacks.rb:416:in `_run_call_callbacks'
actionpack (3.0.10) lib/action_dispatch/middleware/callbacks.rb:44:in`call'
rack (1.2.3) lib/rack/sendfile.rb:107:in `call'
app/middlewares/our_remote_ip.rb:26:in`call'
actionpack (3.0.10) lib/action_dispatch/middleware/show_exceptions.rb:47:in `call'
railties (3.0.10) lib/rails/rack/logger.rb:13:in`call'
rack (1.2.3) lib/rack/runtime.rb:17:in `call'
activesupport (3.0.10) lib/active_support/cache/strategy/local_cache.rb:72:in`call'
rack (1.2.3) lib/rack/lock.rb:11:in `block in call'
<internal:prelude>:10:in`synchronize'
rack (1.2.3) lib/rack/lock.rb:11:in `call'
actionpack (3.0.10) lib/action_dispatch/middleware/static.rb:30:in`call'
hoptoad_notifier (2.4.9) lib/hoptoad_notifier/user_informer.rb:12:in `call'
railties (3.0.10) lib/rails/application.rb:168:in`call'
railties (3.0.10) lib/rails/application.rb:77:in `method_missing'
thin (1.2.11) lib/thin/connection.rb:84:in`block in pre_process'
thin (1.2.11) lib/thin/connection.rb:82:in `catch'
thin (1.2.11) lib/thin/connection.rb:82:in`pre_process'
thin (1.2.11) lib/thin/connection.rb:57:in `process'
thin (1.2.11) lib/thin/connection.rb:42:in`receive_data'
eventmachine (0.12.10) lib/eventmachine.rb:256:in `run_machine'
eventmachine (0.12.10) lib/eventmachine.rb:256:in`run'
thin (1.2.11) lib/thin/backends/base.rb:61:in `start'
thin (1.2.11) lib/thin/server.rb:159:in`start'
thin (1.2.11) lib/thin/controllers/controller.rb:86:in `start'
thin (1.2.11) lib/thin/runner.rb:185:in`run_command'
thin (1.2.11) lib/thin/runner.rb:151:in `run!'
thin (1.2.11) bin/thin:6:in`<top (required)>'
/Users/marcbey/.rvm/gems/ruby-1.9.2-p290/bin/thin:19:in `load'
/Users/marcbey/.rvm/gems/ruby-1.9.2-p290/bin/thin:19:in`<main>'
