### PR TITLE
Use `base` from options if it's passed in

### DIFF
--- a/oa-enterprise/lib/omniauth/strategies/ldap/adaptor.rb
+++ b/oa-enterprise/lib/omniauth/strategies/ldap/adaptor.rb
@@ -125,12 +125,12 @@ module OmniAuth
         end
 
         def search(options={}, &block)
-          base = options[:base]
+          base = options[:base] || @base
           filter = options[:filter]
           limit = options[:limit]
 
           args = {
-            :base => @base,
+            :base => base,
             :filter => filter,
             :size => limit
           }


### PR DESCRIPTION
We're pulling this out of options but never using it.
