### PR TITLE
Fix OAuth2 Instragram spec

### DIFF
--- a/oa-oauth/spec/omniauth/strategies/oauth2/instagram_spec.rb
+++ b/oa-oauth/spec/omniauth/strategies/oauth2/instagram_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe OmniAuth::Strategies::GitHub do
+describe OmniAuth::Strategies::Instagram do
   it_should_behave_like "an oauth2 strategy"
 end


### PR DESCRIPTION
The Instagram Oauth2 spec is apparently testing OmniAuth::Strategies::Github strategy instead of OmniAuth::Strategies::Instagram

This is a simple-as-can-be-one-line fix that corrects the error.
