### PR TITLE
Most Google Oauth2 API not working - Google Email scope fix

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/google_oauth2.rb
+++ b/oa-oauth/lib/omniauth/strategies/google_oauth2.rb
@@ -20,9 +20,9 @@ module OmniAuth
       end
 
       def request_phase
-        google_email_scope = "https://www.googleapis.com/auth/userinfo.email"
-        options[:scope] ||= google_email_scope
-        options[:scope] << "#{google_email_scope}" unless options[:scope] =~ %r[http[s]?:\/\/#{google_email_scope}]
+        google_email_scope = "www.googleapis.com/auth/userinfo.email"
+        options[:scope] ||= "https://#{google_email_scope}"
+        options[:scope] << "https://#{google_email_scope}" unless options[:scope] =~ %r[http[s]?:\/\/#{google_email_scope}]
         redirect client.auth_code.authorize_url(
           {:redirect_uri => callback_url, :response_type => "code"}.merge(options))
       end


### PR DESCRIPTION
Google Oauth2 stratergy is not working most of the Google APIs, unless the email scope is manually provided.(https://www.googleapis.com/auth/userinfo.email) in the initializer.

In line23, the scope for accessing user email will be ovverrided if a scope is already provided in the initializer. So, in the callback phase when oauth tries to retrieve user email, there is an invalid credentials exception (as there is no scope for accessing user email)

So, a fix to add this email scope by default.
