### PR TITLE
OmniAuth::Form.build should call Form.new with :title => title

### DIFF
--- a/lib/omniauth/form.rb
+++ b/lib/omniauth/form.rb
@@ -98,7 +98,7 @@ module OmniAuth
     end
 
     def self.build(title=nil,&block)
-      form = OmniAuth::Form.new(title)
+      form = OmniAuth::Form.new(:title => title)
       if block.arity > 0
         yield form 
       else


### PR DESCRIPTION
Fix for issue #380 - OmniAuth::Form.build calls initialize incorrectly.
