### PR TITLE
Fix for missing space in google email scope (issue #467)

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/google_oauth2.rb
+++ b/oa-oauth/lib/omniauth/strategies/google_oauth2.rb
@@ -22,7 +22,7 @@ module OmniAuth
       def request_phase
         google_email_scope = "www.googleapis.com/auth/userinfo.email"
         options[:scope] ||= "https://#{google_email_scope}"
-        options[:scope] << "https://#{google_email_scope}" unless options[:scope] =~ %r[http[s]?:\/\/#{google_email_scope}]
+        options[:scope] << " https://#{google_email_scope}" unless options[:scope] =~ %r[http[s]?:\/\/#{google_email_scope}]
         redirect client.auth_code.authorize_url(
           {:redirect_uri => callback_url, :response_type => "code"}.merge(options))
       end


### PR DESCRIPTION
Line 25 in OmniAuth::Strategies::GoogleOAuth2 is wrong

options[:scope] << "https://#{google_email_scope}"

has to be replaced with

options[:scope] << " https://#{google_email_scope}"

The leading space is necessary to recognize the default email-scope. Will break with missing credentials otherwise because it will not separate from the last submitted credential and look like .../buzz.readonly/http://.... instead of correct: .../buzz.readonly/http://....

Even better, check for white spaces / trim them at the end of the submitted string.
