### PR TITLE
allow SAML strategy to have a custom name

### DIFF
--- a/oa-enterprise/lib/omniauth/strategies/saml.rb
+++ b/oa-enterprise/lib/omniauth/strategies/saml.rb
@@ -32,6 +32,7 @@ module OmniAuth
           response = OmniAuth::Strategies::SAML::AuthResponse.new(request.params['SAMLResponse'])
           response.settings = @@settings
           @name_id  = response.name_id
+          @extra_attributes = response.attributes
           return fail!(:invalid_ticket, 'Invalid SAML Ticket') if @name_id.nil? || @name_id.empty?
           super
         rescue ArgumentError => e
@@ -41,7 +42,8 @@ module OmniAuth
 
       def auth_hash
         OmniAuth::Utils.deep_merge(super, {
-          'uid' => @name_id
+          'uid' => @name_id,
+          'extra' => @extra_attributes
         })
       end
 


### PR DESCRIPTION
I saw SAML support for OmniAuth (awesome!), but a client of mine needs to integrate more than 1 SAML provider into the app.

This patch adds an optional :name option, which works just like the :name option a lot of other strategies have (for example, the Open ID strategies).

Thus, you can do things like:

```
provider :SAML, :name => "onelogin.com", :idp_sso_target_url => "https://app.onelogin.com....", ....
provider :SAML, :name => "bigco.com", :idp_sso_target_url => "https://identity.bigco.com....", ....
```

and have multiple SAML providers (each with their own target and callback URLs).

cc: @raecoo
