### PR TITLE
0-3-Stable: Resolved issue adding authorize_params to google strategy.

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth/google.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth/google.rb
@@ -59,9 +59,12 @@ module OmniAuth
         @user_hash ||= MultiJson.decode(@access_token.get('https://www.google.com/m8/feeds/contacts/default/full?max-results=1&alt=json').body)
       end
 
-      # Monkeypatch OmniAuth to pass the scope in the consumer.get_request_token call
+      # Monkeypatch OmniAuth to pass the scope and authorize_params in the consumer.get_request_token call
       def request_phase
-        request_token = consumer.get_request_token({:oauth_callback => callback_url}, {:scope => options[:scope]})
+        request_options = {:scope => options[:scope]}
+        request_options.merge!(options[:authorize_params])
+
+        request_token = consumer.get_request_token({:oauth_callback => callback_url}, request_options)
         session['oauth'] ||= {}
         session['oauth'][name.to_s] = {'callback_confirmed' => request_token.callback_confirmed?, 'request_token' => request_token.token, 'request_secret' => request_token.secret}
         r = Rack::Response.new


### PR DESCRIPTION
I ran into an issue trying to pass in xoauth_displayname via the authorize_params hash.  This would actually be a problem when trying to add any parameters other than "scope".

This resolves that issue.

Thanks!
