### PR TITLE
Stop swallowing OAuth2::Error when building access token.

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth2.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth2.rb
@@ -78,8 +78,6 @@ module OmniAuth
       def build_access_token
         verifier = request.params['code']
         client.auth_code.get_token(verifier, {:redirect_uri => callback_url}.merge(options))
-      rescue ::OAuth2::Error => e
-        raise e.response.inspect
       end
 
       def auth_hash


### PR DESCRIPTION
Otherwise Facebook errors will be raised as an runtime exception
which won't be passed by the on_failure callback.
