### PR TITLE
0 3 stable

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/google_oauth2.rb
+++ b/oa-oauth/lib/omniauth/strategies/google_oauth2.rb
@@ -16,7 +16,7 @@ module OmniAuth
           :token_url => '/o/oauth2/token'
         }
 
-        super(app, :google_oauth2, client_id, client_secret, client_options, options, &block)
+        super(app, (options[:name] || :google_oauth2), client_id, client_secret, client_options, options, &block)
       end
 
       def request_phase


### PR DESCRIPTION
set custom route name like the following:

```
Rails.application.config.middleware.use OmniAuth::Builder do
  provider OmniAuth::Strategies::GoogleOAuth2, 'google_key', 'google_secret',
    :scope => "https://www.googleapis.com/auth/plus.me",
    :name => :google
end
```
