### PR TITLE
Stop rescuing all OAuth2::Errors and re-raising as RuntimeErrors

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth2/facebook.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth2/facebook.rb
@@ -42,8 +42,6 @@ module OmniAuth
         @access_token.options[:mode] = :query
         @access_token.options[:param_name] = 'access_token'
         @data ||= @access_token.get('/me').parsed
-      rescue ::OAuth2::Error => e
-        raise e.response.inspect
       end
 
       def request_phase
@@ -60,8 +58,6 @@ module OmniAuth
         else
           super
         end
-      rescue ::OAuth2::Error => e
-        raise e.response.inspect
       end
 
       def facebook_session

--- a/oa-oauth/lib/omniauth/strategies/oauth2/yammer.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth2/yammer.rb
@@ -49,8 +49,6 @@ module OmniAuth
         temp_access_token = client.auth_code.get_token(verifier, {:redirect_uri => callback_url}.merge(options))
         token = eval(temp_access_token.token)['token']
         @access_token = ::OAuth2::AccessToken.new(client, token, temp_access_token.params)
-      rescue ::OAuth2::Error => e
-        raise e.response.inspect
       end
 
       def user_hash


### PR DESCRIPTION
This pull request only removed it in 1 place, but there were several others so I think it makes sense to remove them all:
https://github.com/intridea/omniauth/pull/509

This will actually fix the issue (for realz) described in that pull request for Facebook.
