### PR TITLE
0-3-stable branch: add missing email address to xing strategy

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth/xing.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth/xing.rb
@@ -39,6 +39,7 @@ module OmniAuth
           'first_name'  => person['first_name'],
           'last_name'   => person['last_name'],
           'image'       => person["photo_urls"]["large"],
+          'email'       => person["active_email"],
         }
       end
 


### PR DESCRIPTION
The users email address wasn't fetched in the XING strategy. This commit adds it.
