### PR TITLE
Make instagram strategy fetch user data from full url. Fixes #431

### DIFF
--- a/oa-oauth/lib/omniauth/strategies/oauth2/instagram.rb
+++ b/oa-oauth/lib/omniauth/strategies/oauth2/instagram.rb
@@ -43,7 +43,7 @@ module OmniAuth
 
       def user_data
         @access_token.options.merge!({:param_name => 'access_token', :mode => :query})
-        @data ||= MultiJson.decode(@access_token.get('/v1/users/self'))
+        @data ||= @access_token.get('https://api.instagram.com/v1/users/self').parsed
       end
 
       def user_info


### PR DESCRIPTION
Instagram strategy was failing before because it was not fetching the user info with the domain. Pulling user info from the full user info url now.

This fixes #431 (in combination with https://github.com/intridea/omniauth/commit/729b892c6bba50bc4aa99450e11a682f0f904851, that is already on `0-3-stable`
