### PR TITLE
Address jruby spec issue

### DIFF
--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -546,9 +546,17 @@ describe OmniAuth::Strategy do
         strategy.call(make_env('/auth/test/callback', 'rack.session' => {'omniauth.origin' => 'http://example.com/origin'}))
         strategy.env['omniauth.origin'].should == 'http://example.com/origin'
       end
+      
+      after do
+        OmniAuth.config.test_mode = false
+      end
     end
 
     context 'custom full_host' do
+      before do
+        OmniAuth.config.test_mode = true
+      end
+      
       it 'should be the string when a string is there' do
         OmniAuth.config.full_host = 'my.host.com'
         strategy.full_host.should == 'my.host.com'
@@ -559,10 +567,18 @@ describe OmniAuth::Strategy do
         strategy.call(make_env('/auth/test', 'HOST' => 'my.host.net'))
         strategy.full_host.should == 'my.host.net'
       end
+      
+      after do
+        OmniAuth.config.test_mode = false
+      end
     end
   end
 
   context 'setup phase' do
+    before do
+      OmniAuth.config.test_mode = true
+    end
+    
     context 'when options[:setup] = true' do
       let(:strategy){ ExampleStrategy.new(app, :setup => true) }
       let(:app){lambda{|env| env['omniauth.strategy'].options[:awesome] = 'sauce' if env['PATH_INFO'] == '/auth/test/setup'; [404, {}, 'Awesome'] }}
@@ -596,6 +612,10 @@ describe OmniAuth::Strategy do
         strategy.call(make_env('/auth/test'))
         strategy.options[:awesome].should == 'sauce'
       end
+    end
+    
+    after do
+      OmniAuth.config.test_mode = false
     end
   end
 end


### PR DESCRIPTION
Looks like the strategy_spec is leaving the test_mode to true.

This is actually causing the specs to fail for all rubies, it's just the load order of files is different under jruby. JRuby returns file listings in different order than MRI:

``` bash
[mbpro:~/documents/mkdynamic/omniauth] ∞ master
→ rvm use jruby-1.6.4
[mbpro:~/documents/mkdynamic/omniauth] ∞ master
→ bundle exec rake
/Users/markdodwell/.rvm/rubies/jruby-1.6.4/bin/jruby -S bundle exec rspec ./spec/omniauth_spec.rb ./spec/omniauth/auth_hash_spec.rb ./spec/omniauth/builder_spec.rb ./spec/omniauth/strategy_spec.rb ./spec/omniauth/strategies/developer_spec.rb
```

Under 1.9.2/1.8.7:

``` bash
[mbpro:~/documents/mkdynamic/omniauth] ∞ master
→ rvm use 1.8.7
Using /Users/markdodwell/.rvm/gems/ruby-1.8.7-p352
[mbpro:~/documents/mkdynamic/omniauth] ∞ master
→ bundle exec rake
/Users/markdodwell/.rvm/rubies/ruby-1.8.7-p352/bin/ruby -S bundle exec rspec ./spec/omniauth/auth_hash_spec.rb ./spec/omniauth/builder_spec.rb ./spec/omniauth/strategies/developer_spec.rb ./spec/omniauth/strategy_spec.rb ./spec/omniauth_spec.rb
```

Not sure if this patch is the right fix, but hopefully explains the issue.
