### PR TITLE
Add Etsy OAuth v1 strategy

### DIFF
--- a/oa-core/lib/omniauth/version.rb
+++ b/oa-core/lib/omniauth/version.rb
@@ -10,7 +10,7 @@ module OmniAuth
       PATCH = 2
     end
     unless defined?(::OmniAuth::Version::PRE)
-      PRE = nil
+      PRE   = nil
     end
     unless defined?(::OmniAuth::Version::STRING)
       STRING = [MAJOR, MINOR, PATCH, PRE].compact.join('.')

--- a/oa-oauth/lib/omniauth/oauth.rb
+++ b/oa-oauth/lib/omniauth/oauth.rb
@@ -68,7 +68,10 @@ module OmniAuth
     autoload :Vkontakte,          'omniauth/strategies/oauth2/vkontakte'
     autoload :WePay,              'omniauth/strategies/oauth2/we_pay'
     autoload :Yammer,             'omniauth/strategies/oauth2/yammer'
+
+
     autoload :XAuth,              'omniauth/strategies/xauth'
     autoload :Instapaper,         'omniauth/strategies/xauth/instapaper'
+
   end
 end

--- a/oa-oauth/lib/omniauth/version.rb
+++ b/oa-oauth/lib/omniauth/version.rb
@@ -10,7 +10,7 @@ module OmniAuth
       PATCH = 2
     end
     unless defined?(::OmniAuth::Version::PRE)
-      PRE = nil
+      PRE   = nil
     end
     unless defined?(::OmniAuth::Version::STRING)
       STRING = [MAJOR, MINOR, PATCH, PRE].compact.join('.')

--- a/oa-oauth/oa-oauth.gemspec
+++ b/oa-oauth/oa-oauth.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'faraday', '~> 0.7.3'
   gem.add_dependency 'multi_json', '~> 1.0.0'
   gem.add_dependency 'multi_xml', '~> 0.4.0'
-  gem.add_dependency 'oa-core', ">= #{OmniAuth::Version::STRING}"
+  gem.add_dependency 'oa-core', OmniAuth::Version::STRING
   gem.add_dependency 'oauth', '~> 0.4.0'
   gem.add_dependency 'oauth2', '~> 0.5.0'
   gem.add_development_dependency 'evernote', '~> 1.0'


### PR DESCRIPTION
This strategy adds support for authenticating to the Etsy API via OAuth v1.

Etsy's API supports both sandbox and production environments.  By default this strategy talks to production, though the environment can be set to use the sandbox as well.
