### PR TITLE
Update mock auth to match what is actually returned.

### DIFF
--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -34,7 +34,9 @@ module OmniAuth
         :default => {
           'provider' => 'default',
           'uid' => '1234',
-          'name' => 'Bob Example'
+          'info' => {
+            'name' => 'Bob Example'
+          }
         }
       }
     }


### PR DESCRIPTION
Using mock auth in tests was returning a flat hash without the 'info' key, unlike what is specified in the docs. Only tested with the Facebook strategy, but assuming the docs are right.
