### PR TITLE
Dynamic paths

### DIFF
--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -24,7 +24,12 @@ module OmniAuth
       :path_prefix => '/auth',
       :on_failure => Proc.new do |env|
         message_key = env['omniauth.error.type']
-        new_path = "#{env['SCRIPT_NAME']}#{OmniAuth.config.path_prefix}/failure?message=#{message_key}"
+        if env['omniauth.strategy']
+          failure_path = env['omniauth.strategy'].failure_path
+        else
+          failure_path = "#{OmniAuth.config.path_prefix}/failure"
+        end
+        new_path = "#{env['SCRIPT_NAME']}#{failure_path}?message=#{message_key}"
         [302, {'Location' => new_path, 'Content-Type'=> 'text/html'}, []]
       end,
       :form_css => Form::DEFAULT_CSS,

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -365,6 +365,77 @@ describe OmniAuth::Strategy do
       end
     end
 
+    context 'dynamic paths' do
+      it 'should trigger request phase' do
+        strategy.stub(:full_host).and_return('http://example.com')
+        lambda{ strategy.call(make_env('/auth/test/fresh')) }.should raise_error("Request Phase")
+        lambda{ strategy.call(make_env('/auth/test/fresh/78')) }.should raise_error("Request Phase")
+        lambda{ strategy.call(make_env('/auth/test/fresh/78/')) }.should raise_error("Request Phase")
+      end
+
+      it 'should be passed on to callback url' do
+        strategy.stub(:full_host).and_return('http://example.com')
+        lambda{ strategy.call(make_env('/auth/test/fresh/78')) }.should raise_error("Request Phase")
+        strategy.callback_url.should == 'http://example.com/auth/test/fresh/78/callback'
+      end
+
+      it 'should include query parameters' do
+        strategy.stub(:full_host).and_return('http://example.com')
+        lambda{ strategy.call(make_env('/auth/test/fresh/78', 'QUERY_STRING' => 'id=5')) }.should raise_error("Request Phase")
+        strategy.callback_url.should == 'http://example.com/auth/test/fresh/78/callback?id=5'
+      end
+
+      it 'should strip trailing slash' do
+        strategy.stub(:full_host).and_return('http://example.com')
+        lambda{ strategy.call(make_env('/auth/test/fresh/78/')) }.should raise_error("Request Phase")
+        strategy.callback_url.should == 'http://example.com/auth/test/fresh/78/callback'
+      end
+
+      it 'should be included in failure path' do
+        @options = {:failure => :forced_fail}
+        strategy.stub(:full_host).and_return('http://example.com')
+        begin
+          strategy.call(make_env('/auth/test/fresh/78'))
+        rescue RuntimeError; end
+        OmniAuth.config.on_failure.call(strategy.env)[1]['Location'].should == "/auth/test/fresh/78/failure?message=forced_fail"
+      end
+
+      it 'should not affect simple failure_path when not used' do
+        @options = {:failure => :forced_fail}
+        strategy.stub(:full_host).and_return('http://example.com')
+        begin
+          strategy.call(make_env('/auth/test'))
+        rescue RuntimeError; end
+        OmniAuth.config.on_failure.call(strategy.env)[1]['Location'].should == "/auth/failure?message=forced_fail"
+        begin
+          strategy.call(make_env('/auth/test/'))
+        rescue RuntimeError; end
+        OmniAuth.config.on_failure.call(strategy.env)[1]['Location'].should == "/auth/failure?message=forced_fail"
+      end
+
+      it 'dynamic path should respect custom path_prefix' do
+        @options = {:path_prefix => '/awesome'}
+        strategy.stub(:full_host).and_return('http://example.com')
+        lambda{ strategy.call(make_env('/awesome/test/fresh/78')) }.should raise_error("Request Phase")
+        strategy.callback_url.should == 'http://example.com/awesome/test/fresh/78/callback'
+      end
+
+      it 'dynamic path should respect custom request_path' do
+        @options = {:request_path => '/awesome'}
+        strategy.stub(:full_host).and_return('http://example.com')
+        lambda{ strategy.call(make_env('/awesome/fresh/78')) }.should raise_error("Request Phase")
+        strategy.callback_url.should == 'http://example.com/auth/test/fresh/78/callback'
+      end
+
+      it 'dynamic path should respect custom callback_path' do
+        @options = {:callback_path => '/awesome'}
+        strategy.stub(:full_host).and_return('http://example.com')
+        lambda{ strategy.call(make_env('/auth/test/fresh/78')) }.should raise_error("Request Phase")
+        strategy.callback_url.should == 'http://example.com/awesome/fresh/78'
+      end
+
+    end
+
     context 'custom paths' do
       it 'should use a custom request_path if one is provided' do
         @options = {:request_path => '/awesome'}
@@ -422,7 +493,7 @@ describe OmniAuth::Strategy do
         it 'preserves the query parameters' do
           strategy.stub(:full_host).and_return('http://example.com')
           begin
-            strategy.call(make_env('/auth/test', 'QUERY_STRING' => 'id=5'))
+            strategy.call(make_env('/wowzers/test', 'QUERY_STRING' => 'id=5'))
           rescue RuntimeError; end
           strategy.callback_url.should == 'http://example.com/wowzers/test/callback?id=5'
         end
@@ -625,6 +696,34 @@ describe OmniAuth::Strategy do
       it 'should call the rack app' do
         strategy.call(make_env('/auth/test'))
         strategy.options[:awesome].should == 'sauce'
+      end
+    end
+    
+    context 'when using a dynamic path' do
+      context 'when options[:setup] = true' do
+        let(:strategy){ ExampleStrategy.new(app, :setup => true) }
+        let(:app){lambda{|env| env['omniauth.strategy'].options[:awesome] = 'sauce' if env['PATH_INFO'] == '/auth/test/shiny/23/setup'; [404, {}, 'Awesome'] }}
+
+        it 'should call through to /auth/:provider/dynamic/path/setup' do
+          strategy.stub(:full_host).and_return('http://example.com')
+          strategy.call(make_env('/auth/test/shiny/23'))
+          strategy.callback_url.should == 'http://example.com/auth/test/shiny/23/callback'
+          strategy.options[:awesome].should == 'sauce'
+        end
+      end
+
+      context 'when options[:setup] is an app' do
+        let(:setup_proc) do
+          Proc.new do |env|
+            env['omniauth.strategy'].options[:awesome] = 'sauce'
+          end
+        end
+        let(:strategy){ ExampleStrategy.new(app, :setup => setup_proc) }
+
+        it 'should call the rack app' do
+          strategy.call(make_env('/auth/test/shiny/23'))
+          strategy.options[:awesome].should == 'sauce'
+        end
       end
     end
 


### PR DESCRIPTION
dynamic paths for 1.0.

dynamic paths allow you to start authorization from a path like auth/twittter/my/path, which then results in a callback at auth/twitter/my/path/callback. setup and failure works the same way.

this is quite useful for scenarios where you're not just logging in a user, but authorize different items like projects or accounts. in these situations, using the same callback route is inpractical.

traditional paths should not be affected.

it works for me with both twitter and facebook, and all tests pass. test are included for the dynamic paths. but there's still a few things i wonder about, like what's going on around line 187 in lib/omniauth/strategy.rb:

if request.params['origin']
env['rack.session']['omniauth.origin'] = request.params['origin']
elsif env['HTTP_REFERER'] && !env['HTTP_REFERER'].match(/#{request_path}$/) #when would this happen?
env['rack.session']['omniauth.origin'] = env['HTTP_REFERER']
end

feedback welcome :-)
