### PR TITLE
A request to insert env['SCRIPT_NAME'] before on_failure new_path

### DIFF
--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -24,7 +24,7 @@ module OmniAuth
       :path_prefix => '/auth',
       :on_failure => Proc.new do |env|
         message_key = env['omniauth.error.type']
-        new_path = "#{OmniAuth.config.path_prefix}/failure?message=#{message_key}"
+        new_path = "#{env['SCRIPT_NAME']}#{OmniAuth.config.path_prefix}/failure?message=#{message_key}"
         [302, {'Location' => new_path, 'Content-Type'=> 'text/html'}, []]
       end,
       :form_css => Form::DEFAULT_CSS,

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -496,6 +496,18 @@ describe OmniAuth::Strategy do
         response[1]['Location'].should == '/sub_uri/auth/test/callback'
       end
 
+      it 'should redirect on failure' do
+        response = OmniAuth.config.on_failure.call(make_env('/auth/test', 'omniauth.error.type' => 'error'))
+        response[0].should == 302
+        response[1]['Location'].should == '/auth/failure?message=error'
+      end
+
+      it 'should respect SCRIPT_NAME (a.k.a. BaseURI) on failure' do
+        response = OmniAuth.config.on_failure.call(make_env('/auth/test', 'SCRIPT_NAME' => '/sub_uri', 'omniauth.error.type' => 'error'))
+        response[0].should == 302
+        response[1]['Location'].should == '/sub_uri/auth/failure?message=error'
+      end
+
       it 'should be case insensitive on callback path' do
         strategy.call(make_env('/AUTH/TeSt/CaLlBAck')).should == strategy.call(make_env('/auth/test/callback'))
       end


### PR DESCRIPTION
Hi,

Current implementation of on_failure seems not to consider application prefix like 'sub URI' in Passenger. If possible, would you insert env['SCRIPT_NAME'] into new_path?

% vi lib/omniauth.rb
...
      :on_failure => Proc.new do |env|
        message_key = env['omniauth.error.type']
        new_path = "#{env['SCRIPT_NAME']}#{OmniAuth.config.path_prefix}/failure?message=#{message_key}"
        [302, {'Location' => new_path, 'Content-Type'=> 'text/html'}, []]
      end,
...

The failure message is important for the frontend module base authentication systems like Shibboleth, OpenSSO. Before configuring frontend authentication, only the failure message can give users a hint to fix the issue why then can not log in.

I am not sure that the test code should be written in spec/omniauth/strategy_spec.rb or not. However, the most of sub_uri tests are located here. So thus, I added test code of on_failure into strategy_spec.rb 'test mode' context.

Best Regards
