### PR TITLE
Make omniauth.auth a Mash in test mode as well

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -253,7 +253,7 @@ module OmniAuth
       if mocked_auth.is_a?(Symbol)
         fail!(mocked_auth)
       else
-        @env['omniauth.auth'] = mocked_auth
+        @env['omniauth.auth'] = Hashie::Mash.new(mocked_auth)
         @env['omniauth.params'] = session.delete('query_params') || {}
         @env['omniauth.origin'] = session.delete('omniauth.origin')
         @env['omniauth.origin'] = nil if env['omniauth.origin'] == ''

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -546,7 +546,14 @@ describe OmniAuth::Strategy do
         strategy.call(make_env('/auth/test/callback', 'rack.session' => {'omniauth.origin' => 'http://example.com/origin'}))
         strategy.env['omniauth.origin'].should == 'http://example.com/origin'
       end
-      
+
+      it 'should set omniauth.auth as an instance of Hashie::Mash' do
+        OmniAuth.config.mock_auth[:test] = {}
+
+        strategy.call make_env('/auth/test/callback')
+        strategy.env['omniauth.auth'].should be_a(Hashie::Mash)
+      end
+
       after do
         OmniAuth.config.test_mode = false
       end


### PR DESCRIPTION
Normally omniauth sets the omniauth.auth to be a subclass of Hashie::Mash. So if I rely on it having particular methods in my application code it breaks in integration tests if I use test mode.
