### PR TITLE
mock_auth['default'] is a hash instead of being an AuthHash ( https://github.com/intridea/omniauth/issues/558 )

### DIFF
--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -31,13 +31,13 @@ module OmniAuth
       :test_mode => false,
       :allowed_request_methods => [:get, :post],
       :mock_auth => {
-        :default => {
+        :default => AuthHash.new(
           'provider' => 'default',
           'uid' => '1234',
           'info' => {
             'name' => 'Bob Example'
           }
-        }
+        )
       }
     }
 

--- a/spec/omniauth_spec.rb
+++ b/spec/omniauth_spec.rb
@@ -52,6 +52,28 @@ describe OmniAuth do
 
       OmniAuth.config.on_failure.call.should == 'yoyo'
     end
+    describe 'mock auth' do
+      before do
+        OmniAuth.config.add_mock(:facebook, :uid => '12345',:info=>{:name=>'Joe', :email=>'joe@example.com'})
+      end
+      it 'default should be AuthHash' do
+        OmniAuth.configure do |config|
+          config.mock_auth[:default].should be_kind_of(OmniAuth::AuthHash)
+        end
+      end
+      it 'facebook should be AuthHash' do
+        OmniAuth.configure do |config|
+          config.mock_auth[:facebook].should be_kind_of(OmniAuth::AuthHash)
+        end        
+      end
+      it 'should set facebook attributes' do
+        OmniAuth.configure do |config|
+          config.mock_auth[:facebook].uid.should eq('12345')
+          config.mock_auth[:facebook].info.name.should eq('Joe')
+          config.mock_auth[:facebook].info.email.should eq('joe@example.com')
+        end
+      end
+    end
   end
 
   describe '::Utils' do


### PR DESCRIPTION
I'm getting failing tests using

omniauth.info.email because omniauth is a hash. This is a patch to fix it.

`undefined method 'info' for #<Hash:0x00000006f1daa0>`

Also its a response for this issue: https://github.com/intridea/omniauth/issues/558
