### PR TITLE
readme: 'use Rack::Session::Cookie'

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ require 'sinatra'
 require 'omniauth'
 
 class MyApplication < Sinatra::Base
-  use Rack::Session
+  use Rack::Session::Cookie
   use OmniAuth::Strategies::Developer
 end
 ```


### PR DESCRIPTION
Hi!

This provides a small fix to the README, as `use Rack::Session` is an invalid statement (as far as I can tell, at least).
