### PR TITLE
handling HTTP_X_FORWARDED_PROTO header

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -376,6 +376,8 @@ module OmniAuth
           uri = URI.parse(request.url.gsub(/\?.*$/,''))
           uri.path = ''
           uri.query = nil
+          #sometimes the url is actually showing http inside rails because the other layers (like nginx) have handled the ssl termination.
+          uri.scheme = 'https' if(request.env['HTTP_X_FORWARDED_PROTO'] == 'https')          
           uri.to_s
       end
     end


### PR DESCRIPTION
In many installations, https transport is handled by the nginx layer and HTTP_X_FORWARDED_PROTO header is set to specify that the original request was https. This change will handle that situation.

We are using this change in production for more than 5 months now.

Thanks a lot
