### PR TITLE
Strategy#mock_request_call bug

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -237,7 +237,9 @@ module OmniAuth
 
     def mock_request_call
       setup_phase
-      return response if response = call_through_to_app
+      if response = call_through_to_app
+        return response
+      end
 
       if request.params['origin']
         @env['rack.session']['omniauth.origin'] = request.params['origin']


### PR DESCRIPTION
This code illustrates the issue:

```
class TestCase

  attr_reader :response

  def initialize
    @response = "What will be returned"
  end

  def call_through_to_app
    "What is supposed to be returned"
  end

  def mock_request_call
    return response if response = call_through_to_app
  end
end

test = TestCase.new
puts test.mock_request_call
```

This code in _Strategy_ does not seem to do what it was supposed to be doing. Fixing this made my OmniAuth Facebook/Twitter tests green again.
