### PR TITLE
Fix test strategy to include options and other phases

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -230,8 +230,10 @@ module OmniAuth
     # in the event that OmniAuth has been configured to be
     # in test mode.
     def mock_call!(env)
+      return options_call if on_auth_path? && options_request?
       return mock_request_call if on_request_path?
       return mock_callback_call if on_callback_path?
+      return other_phase if respond_to?(:other_phase)
       call_app!
     end
 


### PR DESCRIPTION
Not sure if there was a reason for this, but it was causing issues with `omniauth-identity` in test mode since it did not recognize the registration phase which is defined in that strategy's `other_phase`.

If this looks like a bug, will do something better and add some specs.
