### PR TITLE
Fix threadsafety issue for multithreaded apps

### DIFF
--- a/lib/omniauth/builder.rb
+++ b/lib/omniauth/builder.rb
@@ -8,6 +8,7 @@ module OmniAuth
       else
         @app = app
         super(&block)
+        @ins << @app
       end
     end
 
@@ -44,7 +45,6 @@ module OmniAuth
     end
 
     def call(env)
-      @ins << @app unless rack14? || @ins.include?(@app)
       to_app.call(env)
     end
   end


### PR DESCRIPTION
We use JRuby, and encountered a problem where our servers would occasionally return all 500s after startup with this stack trace:

```
/!\ FAILSAFE /!\  2012-05-21 17:59:15 -0500
  Status: 500 Internal Server Error
  undefined method `key?' for #<ActiveRecord::ConnectionAdapters::ConnectionManagement:0x4e08ad5e>
    /var/www/sites/spiceworks/frontend.shared/bundle/jruby/1.9/gems/activerecord-2.3.11/lib/active_record/connection_adapters/abstract/connection_pool.rb:365:in `call'
    /var/www/sites/spiceworks/frontend.shared/bundle/jruby/1.9/gems/rack-1.1.3/lib/rack/builder.rb:73:in `to_app'
    org/jruby/RubyArray.java:1615:in `each'
    org/jruby/RubyEnumerable.java:830:in `inject'
    /var/www/sites/spiceworks/frontend.shared/bundle/jruby/1.9/gems/rack-1.1.3/lib/rack/builder.rb:73:in `to_app'
    /var/www/sites/spiceworks/frontend.shared/bundle/jruby/1.9/gems/omniauth-1.0.2/lib/omniauth/builder.rb:42:in `call'
    /var/www/sites/spiceworks/frontend.shared/bundle/jruby/1.9/gems/actionpack-2.3.11/lib/action_controller/string_coercion.rb:25:in `call'
    /var/www/sites/spiceworks/frontend.shared/bundle/jruby/1.9/gems/rack-1.1.3/lib/rack/head.rb:9:in `call'
    /var/www/sites/spiceworks/frontend.shared/bundle/jruby/1.9/gems/rack-1.1.3/lib/rack/methodoverride.rb:24:in `call'
    /var/www/sites/spiceworks/frontend.shared/bundle/jruby/1.9/gems/actionpack-2.3.11/lib/action_controller/params_parser.rb:15:in `call'
    /var/www/sites/spiceworks/frontend.shared/bundle/jruby/1.9/gems/actionpack-2.3.11/lib/action_controller/session/cookie_store.rb:99:in `call'
    /var/www/sites/spiceworks/frontend.shared/bundle/jruby/1.9/gems/activesupport-2.3.11/lib/active_support/cache/strategy/local_cache.rb:36:in `call'
    /var/www/sites/spiceworks/frontend.shared/bundle/jruby/1.9/gems/actionpack-2.3.11/lib/action_controller/failsafe.rb:26:in `call'
    /var/www/sites/spiceworks/frontend.shared/bundle/jruby/1.9/gems/actionpack-2.3.11/lib/action_controller/dispatcher.rb:106:in `call'
```

This pull requests appends @app to the @ins collection right after the initialization block is executed so that it's guaranteed to only be added once. This is way cheaper than adding synchronization to Omniauth::Builder#call, and still has the same effect as the old code without the race condition.
