### PR TITLE
Problem with mock_request_call and mock_callback_call methods not preserving the omniauth.params hash

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -261,6 +261,8 @@ module OmniAuth
     def mock_request_call
       setup_phase
 
+      session['omniauth.params'] = request.params
+
       if request.params['origin']
         @env['rack.session']['omniauth.origin'] = request.params['origin']
       elsif env['HTTP_REFERER'] && !env['HTTP_REFERER'].match(/#{request_path}$/)
@@ -276,7 +278,7 @@ module OmniAuth
         fail!(mocked_auth)
       else
         @env['omniauth.auth'] = mocked_auth
-        @env['omniauth.params'] = session.delete('query_params') || {}
+        @env['omniauth.params'] = session.delete('omniauth.params') || {}
         @env['omniauth.origin'] = session.delete('omniauth.origin')
         @env['omniauth.origin'] = nil if env['omniauth.origin'] == ''
         call_app!

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -564,6 +564,20 @@ describe OmniAuth::Strategy do
         strategy.env['omniauth.origin'].should == 'http://example.com/origin'
       end
 
+      it 'should set omniauth.params on the request phase' do
+        OmniAuth.config.mock_auth[:test] = {}
+
+        strategy.call(make_env('/auth/test', 'QUERY_STRING' => 'foo=bar'))
+        strategy.env['rack.session']['omniauth.params'].should == {'foo' => 'bar'}
+      end
+
+      it 'should turn omniauth.params into an env variable on the callback phase' do
+        OmniAuth.config.mock_auth[:test] = {}
+
+        strategy.call(make_env('/auth/test/callback', 'rack.session' => {'omniauth.params' => {'foo' => 'bar'}}))
+        strategy.env['omniauth.params'].should == {'foo' => 'bar'}
+      end
+
       after do
         OmniAuth.config.test_mode = false
       end


### PR DESCRIPTION
The fix is pretty simple.
