### PR TITLE
Rely on Rack::Request#ssl? rather than reproducing its logic

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -405,7 +405,7 @@ module OmniAuth
           uri.path = ''
           uri.query = nil
           #sometimes the url is actually showing http inside rails because the other layers (like nginx) have handled the ssl termination.
-          uri.scheme = 'https' if(request.env['HTTP_X_FORWARDED_PROTO'] == 'https')          
+          uri.scheme = 'https' if request.ssl?
           uri.to_s
       end
     end


### PR DESCRIPTION
Rack::Request#ssl? checks HTTP_X_FORWARDED_PROTO. Use that method instead of reproducing it's logic so that ssl determination is centralized.
