### PR TITLE
using set full_path in test mode too

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -268,7 +268,7 @@ module OmniAuth
       elsif env['HTTP_REFERER'] && !env['HTTP_REFERER'].match(/#{request_path}$/)
         @env['rack.session']['omniauth.origin'] = env['HTTP_REFERER']
       end
-      redirect(script_name + callback_path + query_string)
+      redirect(full_host + script_name + callback_path + query_string)
     end
 
     def mock_callback_call

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -528,6 +528,12 @@ describe OmniAuth::Strategy do
         expect(response[1]['Location']).to eq('/auth/test/callback?cheese=stilton')
       end
 
+      it "respects set full host" do
+        OmniAuth.config.full_host = 'http://test.local'
+        response = strategy.call(make_env)
+        expect(response[1]['Location']).to eq('http://test.local/auth/test/callback')
+      end
+
       it "does not short circuit requests outside of authentication" do
         expect(strategy.call(make_env('/'))).to eq(app.call(make_env('/')))
       end


### PR DESCRIPTION
Here is my take on the issue https://github.com/intridea/omniauth/issues/656. But I lack the detailed understanding of Rack to fix the failing test. Maybe you or someone else knows the solution right away.

```
OmniAuth::Strategy setup phase when options[:setup] = true calls through to /auth/:provider/setup
 Failure/Error: strategy.call(make_env('/auth/test'))
 NoMethodError:
   undefined method `+' for nil:NilClass
 # ./lib/omniauth/strategy.rb:404:in `full_host'
 # ./lib/omniauth/strategy.rb:271:in `mock_request_call'
 # ./lib/omniauth/strategy.rb:256:in `mock_call!'
 # ./lib/omniauth/strategy.rb:171:in `call!'
```
