### PR TITLE
Refactor ssl check

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -403,9 +403,8 @@ module OmniAuth
         else
           uri = URI.parse(request.url.gsub(/\?.*$/,''))
           uri.path = ''
-          uri.query = nil
           #sometimes the url is actually showing http inside rails because the other layers (like nginx) have handled the ssl termination.
-          uri.scheme = 'https' if(request.env['HTTP_X_FORWARDED_PROTO'] == 'https')
+          uri.scheme = 'https' if ssl?
           uri.to_s
       end
     end
@@ -465,6 +464,13 @@ module OmniAuth
 
     def merge_stack(stack)
       stack.inject({}){|c,h| c.merge!(h); c}
+    end
+    def ssl?
+      request.env['HTTPS'] == 'on' ||
+      request.env['HTTP_X_FORWARDED_SSL'] == 'on' ||
+      request.env['HTTP_X_FORWARDED_SCHEME'] == 'https' ||
+      (request.env['HTTP_X_FORWARDED_PROTO'] && request.env['HTTP_X_FORWARDED_PROTO'].split(',')[0] == 'https') ||
+      request.env['rack.url_scheme'] == 'https'
     end
   end
 end

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -607,6 +607,18 @@ describe OmniAuth::Strategy do
         expect(strategy.full_host).to eq('my.host.net')
       end
 
+      it "is based on the request if it's not a string nor a proc" do
+        OmniAuth.config.full_host = nil
+        strategy.call(make_env('/whatever', 'rack.url_scheme' => 'http', 'SERVER_NAME' => 'my.host.net', 'SERVER_PORT' => 80))
+        expect(strategy.full_host).to eq('http://my.host.net')
+      end
+
+      it "should honor HTTP_X_FORWARDED_PROTO if present" do
+        OmniAuth.config.full_host = nil
+        strategy.call(make_env('/whatever', 'HTTP_X_FORWARDED_PROTO' => 'https','rack.url_scheme' => 'http', 'SERVER_NAME' => 'my.host.net', 'SERVER_PORT' => 443))
+        expect(strategy.full_host).to eq('https://my.host.net')
+      end
+
       after do
         OmniAuth.config.test_mode = false
       end


### PR DESCRIPTION
I've refactored the ssl check to mimic Rack::Request#ssl? behavior as stated in #663. I've removed the query = nil assigment too since it looked redundant just after the gsub and added a few test for a custom full_host that were not provided before.
