### PR TITLE
Block in Strategy.configure can return nil

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -50,8 +50,11 @@ module OmniAuth
       #     configure foo: 'bar'
       #   end
       def configure(options = nil)
-        yield default_options and return unless options
-        default_options.deep_merge!(options)
+        if block_given?
+          yield default_options
+        else
+          default_options.deep_merge!(options)
+        end
       end
 
       # Directly declare a default option for your class. This is a useful from

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -28,11 +28,22 @@ describe OmniAuth::Strategy do
 
   describe ".configure" do
     subject { klass = Class.new; klass.send :include, OmniAuth::Strategy; klass }
-    it "takes a block and allow for default options setting" do
-      subject.configure do |c|
-        c.wakka = 'doo'
+    context "when block is passed" do
+      it "allows for default options setting" do
+        subject.configure do |c|
+          c.wakka = 'doo'
+        end
+        expect(subject.default_options["wakka"]).to eq("doo")
       end
-      expect(subject.default_options["wakka"]).to eq("doo")
+
+      it "works when block doesn't evaluate to true" do
+        environment_variable = nil
+        subject.configure do |c|
+          c.abc = '123'
+          c.hgi = environment_variable
+        end
+        expect(subject.default_options["abc"]).to eq("123")
+      end
     end
 
     it "takes a hash and deep merge it" do


### PR DESCRIPTION
In situations like this:

``` ruby
class MyStrategy
  include OmniAuth::Strategy
  configure do |c|
    c.baz = 123
    c.foo = ENV['BAR']
  end
end
```

the last assignment can return nil. This raises an error with unhelpful message `NoMethodError: undefined method 'each_pair' for nil:NilClass`
