### PR TITLE
Adding authenticity token so session will persist

### DIFF
--- a/lib/omniauth/form.rb
+++ b/lib/omniauth/form.rb
@@ -119,6 +119,10 @@ module OmniAuth
       self
     end
 
+    def authenticity_token_field(token)
+      @html << "\n<input type='hidden' name='authenticity_token' value='#{token}' />"
+    end
+
     def text_field(label, name)
       label_field(label, name)
       input_field('text', name)

--- a/lib/omniauth/strategies/developer.rb
+++ b/lib/omniauth/strategies/developer.rb
@@ -38,6 +38,7 @@ module OmniAuth
 
       def request_phase
         form = OmniAuth::Form.new(:title => "User Info", :url => callback_path)
+        form.authenticity_token_field(session[:_csrf_token])
         options.fields.each do |field|
           form.text_field field.to_s.capitalize.gsub("_", " "), field.to_s
         end

--- a/lib/omniauth/strategies/developer.rb
+++ b/lib/omniauth/strategies/developer.rb
@@ -1,4 +1,5 @@
 require 'omniauth'
+require 'securerandom'
 
 module OmniAuth
   module Strategies
@@ -38,7 +39,7 @@ module OmniAuth
 
       def request_phase
         form = OmniAuth::Form.new(:title => "User Info", :url => callback_path)
-        form.authenticity_token_field(session[:_csrf_token])
+        form.authenticity_token_field(form_authenticity_token)
         options.fields.each do |field|
           form.text_field field.to_s.capitalize.gsub("_", " "), field.to_s
         end
@@ -55,6 +56,12 @@ module OmniAuth
           hash[field] = request.params[field.to_s]
           hash
         end
+      end
+
+      private
+
+      def form_authenticity_token
+        session[:_csrf_token] ||= SecureRandom.base64(32)
       end
     end
   end

--- a/spec/omniauth/strategies/developer_spec.rb
+++ b/spec/omniauth/strategies/developer_spec.rb
@@ -20,7 +20,11 @@ describe OmniAuth::Strategies::Developer do
     end
 
     it "has a text field for each of the fields" do
-      expect(last_response.body.scan('<input').size).to eq(2)
+      expect(last_response.body.scan("<input type='text'").size).to eq(2)
+    end
+
+    it "has a hidden field with the csrf token" do
+      expect(last_response.body.scan("<input type='hidden'").size).to eq(1)
     end
   end
 


### PR DESCRIPTION
This fixes issue #670
When using the developer login strategy sessions are not being persisted
in Rails 4.0.0.beta1 because the authenticity token is not present when
submitting the form. By adding the CSRF token to the form as a hidden
field, it can be verified, and sessions work properly.