### PR TITLE
Dynamic Paths: Callback path not being correctly reported when custom callback path evaluator is truthy

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -241,11 +241,7 @@ module OmniAuth
     end
 
     def on_callback_path?
-      if options.callback_path.respond_to?(:call)
-        options.callback_path.call(env)
-      else
-        on_path?(callback_path)
-      end
+      on_path?(callback_path)
     end
 
     def on_path?(path)
@@ -382,7 +378,10 @@ module OmniAuth
     end
 
     def callback_path
-      options[:callback_path].is_a?(String) ? options[:callback_path] : (custom_path(:request_path) || "#{path_prefix}/#{name}/callback")
+      path = options[:callback_path] if options[:callback_path].is_a?(String)
+      path ||= current_path if options[:callback_path].respond_to?(:call) && options[:callback_path].call(env)
+      path ||= custom_path(:request_path)
+      path ||= "#{path_prefix}/#{name}/callback"
     end
 
     def setup_path

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -384,6 +384,15 @@ describe OmniAuth::Strategy do
         strategy_instance = fresh_strategy.new(nil, :request_path => lambda{|env| "/auth/boo/callback/22" })
         expect(strategy_instance.callback_path).to eq('/auth/boo/callback/22')
       end
+
+      it "correctly reports the callback path when the custom callback path evaluator is truthy" do
+        strategy_instance = ExampleStrategy.new(app,
+          :callback_path => lambda{|env| env['PATH_INFO'] == "/auth/bish/bosh/callback"}
+        )
+
+        expect{strategy_instance.call(make_env('/auth/bish/bosh/callback')) }.to raise_error("Callback Phase")
+        expect(strategy_instance.callback_path).to eq('/auth/bish/bosh/callback')
+      end
     end
 
     context "custom paths" do


### PR DESCRIPTION
In using `omniauth-youtube`, I kept getting the following error on the callback phase:

```
(youtube) Callback phase initiated.
(youtube) Authentication failure! invalid_credentials: OAuth2::Error, redirect_uri_mismatch: 
{
  "error" : "redirect_uri_mismatch"
}
```

It turned out that when dynamically setting the callback path (with a lambda), the callback_path on the strategy was not correctly set during the callback phase.  When `omniauth-oauth2` tried to build an access token, it sent the wrong redirect URL, and Google's API would respond with an error.

https://github.com/intridea/omniauth-oauth2/blob/master/lib/omniauth/strategies/oauth2.rb#L100

I've made some changes to fix this by using the current_path as the callback path whenever the custom callback path evaluator is truthy.
