### PR TITLE
change readme instructions to use `get` in routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ steps are necessary for your application. For example, in a Rails app I
 would add a line in my `routes.rb` file like this:
 
 ```ruby
-match '/auth/:provider/callback', to: 'sessions#create'
+get '/auth/:provider/callback', to: 'sessions#create'
 ```
 
 And I might then have a `SessionsController` with code that looks


### PR DESCRIPTION
Rails 4 deprecates `match` in routes, and this redirect will always be a `get`, so I think it would be helpful to start promoting this method.
