### PR TITLE
Add Ruby 2 to the list of supported Ruby versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ your first stop if you are wondering about a more in-depth look at
 OmniAuth, how it works, and how to use it.
 
 ## Supported Ruby Versions
-OmniAuth is tested under 1.8.7, 1.9.2, 1.9.3, JRuby (1.8 mode), and Rubinius
+OmniAuth is tested under 1.8.7, 1.9.2, 1.9.3, 2.0.0, JRuby (1.8 mode), and Rubinius
 (1.8 and 1.9 modes).
 
 ## Versioning


### PR DESCRIPTION
Since the tests are all passing on travis (https://travis-ci.org/intridea/omniauth), is it safe to say that Ruby 2 is a supported version?
