### PR TITLE
strategy defalut name should use ClassName.to_s.underscore

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -1,4 +1,5 @@
 require 'omniauth'
+require 'omniauth/string_ext'
 require 'hashie/mash'
 
 module OmniAuth
@@ -133,7 +134,7 @@ module OmniAuth
       @options = self.class.default_options.dup
 
       options.deep_merge!(args.pop) if args.last.is_a?(Hash)
-      options.name ||= self.class.to_s.split('::').last.downcase
+      options.name ||= self.class.to_s.split('::').last.underscore
 
       self.class.args.each do |arg|
         options[arg] = args.shift

--- a/lib/omniauth/string_ext.rb
+++ b/lib/omniauth/string_ext.rb
@@ -1,0 +1,14 @@
+# encoding: utf-8
+class String
+  unless String.method_defined?(:underscore)
+    def underscore
+      word = self.to_s.dup
+      word.gsub!(/::/, '/')
+      word.gsub!(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
+      word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
+      word.tr!("-", "_")
+      word.downcase!
+      word
+    end
+  end
+end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -44,3 +44,7 @@ class ExampleStrategy
     raise "Callback Phase"
   end
 end
+
+class Example1Strategy
+  include OmniAuth::Strategy
+end

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -53,6 +53,12 @@ describe OmniAuth::Strategy do
     end
   end
 
+  describe "#name" do
+    it "name should be as expected" do
+      expect(Example1Strategy.new(app).options.name).to be_eql('example1_strategy')
+    end
+  end
+
   describe "#skip_info?" do
     it "is true if options.skip_info is true" do
       expect(ExampleStrategy.new(app, :skip_info => true)).to be_skip_info


### PR DESCRIPTION
strategy defalut name should use ClassName.to_s.underscore,cause in my app, omniauth strategy class name is JoshId, but i don't set option :name, 'josh_id',it get strategy name is joshid not josh_id.
