### PR TITLE
Make raise_out! configurable

### DIFF
--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -33,6 +33,7 @@ module OmniAuth
       :camelizations => {},
       :path_prefix => '/auth',
       :on_failure => OmniAuth::FailureEndpoint,
+      :failure_raise_out_environments => ['development'],
       :form_css => Form::DEFAULT_CSS,
       :test_mode => false,
       :logger => default_logger,
@@ -96,7 +97,7 @@ module OmniAuth
     end
 
     attr_writer :on_failure
-    attr_accessor :path_prefix, :allowed_request_methods, :form_css, :test_mode, :mock_auth, :full_host, :camelizations, :logger
+    attr_accessor :failure_raise_out_environments, :path_prefix, :allowed_request_methods, :form_css, :test_mode, :mock_auth, :full_host, :camelizations, :logger
   end
 
   def self.config

--- a/lib/omniauth/failure_endpoint.rb
+++ b/lib/omniauth/failure_endpoint.rb
@@ -17,7 +17,7 @@ module OmniAuth
     end
 
     def call
-      raise_out! if ENV['RACK_ENV'].to_s == 'development'
+      raise_out! if OmniAuth.config.failure_raise_out_environments.include?(ENV['RACK_ENV'])
       redirect_to_failure
     end
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -13,6 +13,7 @@ require 'omniauth'
 require 'omniauth/test'
 
 OmniAuth.config.logger = Logger.new("/dev/null")
+ENV['RACK_ENV'] ||= 'test'
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods

--- a/spec/omniauth/failure_endpoint_spec.rb
+++ b/spec/omniauth/failure_endpoint_spec.rb
@@ -3,10 +3,9 @@ require 'helper'
 describe OmniAuth::FailureEndpoint do
   subject{ OmniAuth::FailureEndpoint }
 
-  context "development" do
+  context "raise-out environment" do
     before do
-      @rack_env = ENV['RACK_ENV']
-      ENV['RACK_ENV'] = 'development'
+      @default, OmniAuth.config.failure_raise_out_environments = OmniAuth.config.failure_raise_out_environments, ['test']
     end
 
     it "raises out the error" do
@@ -20,11 +19,11 @@ describe OmniAuth::FailureEndpoint do
     end
 
     after do
-      ENV['RACK_ENV'] = @rack_env
+      OmniAuth.config.failure_raise_out_environments = @default
     end
   end
 
-  context "non-development" do
+  context "non-raise-out environment" do
     let(:env){ {'omniauth.error.type' => 'invalid_request',
                 'omniauth.error.strategy' => ExampleStrategy.new({}) } }
 


### PR DESCRIPTION
So that development can behave like production if we're building features around the failure handler
