### PR TITLE
Fix callback controllers not working when using a non-default MIME type.

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -245,7 +245,16 @@ module OmniAuth
     end
 
     def on_path?(path)
-      current_path.casecmp(path) == 0
+      begin
+        route = Rails.application.routes.recognize_path(current_path)
+        route[:only_path] = true
+        #strip the format
+        route[:format] = nil
+
+        Rails.application.routes.url_for(route).casecmp(path) == 0
+      rescue
+        false
+      end
     end
 
     def options_request?


### PR DESCRIPTION
This code makes "on_path?" comparisons in Strategy.rb MIME type agnostic. Please review carefully as I am inexperienced with RoR work and just needed a fix for something I was working on.

Basically, on_path? being MIME type sensitive becomes a problem if someone wants to use a non-default type in their callbacks. In my case I had the route /users/auth/:action/callback(.:format) leading to my omniauth callbacks controller.

I have special template and redirect behaviour for the .tpl format and I used /users/auth/facebook/callback.tpl as a callback which resulted in request.env["omniauth.auth"] not being populated because OmniAuth incorrectly determined I was not on a callback path.

I'm not sure if there is a better way to accomplish this check. Any form of simple pattern matching has the chance of unintended positive matches if people get creative with their routes. 
