### PR TITLE
2 digits of precision for multi_json dependency

### DIFF
--- a/oa-more/oa-more.gemspec
+++ b/oa-more/oa-more.gemspec
@@ -2,7 +2,7 @@
 require File.expand_path('../lib/omniauth/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.add_dependency 'multi_json',   '~> 1.0.0'
+  gem.add_dependency 'multi_json',   '~> 1.0'
   gem.add_dependency 'oa-core', OmniAuth::Version::STRING
   gem.add_dependency 'rest-client',  '~> 1.6.0'
   gem.add_development_dependency 'json_pure', '~> 1.5'

--- a/oa-oauth/oa-oauth.gemspec
+++ b/oa-oauth/oa-oauth.gemspec
@@ -3,7 +3,7 @@ require File.expand_path('../lib/omniauth/version', __FILE__)
 
 Gem::Specification.new do |gem|
   gem.add_dependency 'faraday', '~> 0.7.3'
-  gem.add_dependency 'multi_json', '~> 1.0.0'
+  gem.add_dependency 'multi_json', '~> 1.0'
   gem.add_dependency 'multi_xml', '~> 0.4.0'
   gem.add_dependency 'oa-core', OmniAuth::Version::STRING
   gem.add_dependency 'oauth', '~> 0.4.0'


### PR DESCRIPTION
multi_json tries to adhere to http://semver.org/, and its authors recommend
(https://github.com/intridea/multi_json#versioning) bundling with 2 digits of
precision in a pessimistic version constraint. The earlier, stricter precision
level, conflicts with newer gems' dependencies on multi_json (like "~>1.3").
