### PR TITLE
Fix example callback route to be POST, not GET (in Readme).

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ steps are necessary for your application. For example, in a Rails app I
 would add a line in my `routes.rb` file like this:
 
 ```ruby
-get '/auth/:provider/callback', to: 'sessions#create'
+post '/auth/:provider/callback', to: 'sessions#create'
 ```
 
 And I might then have a `SessionsController` with code that looks


### PR DESCRIPTION
- tiny change in README to update the route from `get` to `post`.
