### PR TITLE
Require omniauth.rb in strategy.rb

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -1,3 +1,4 @@
+require 'omniauth'
 require 'hashie/mash'
 
 module OmniAuth


### PR DESCRIPTION
Without this, the usage of `OmniAuth.strategies` on line 12 (previously line 11) sometimes fails with `undefined method 'strategies' for OmniAuth:Module (NoMethodError)` when strategy.rb is required from a dependent gem without omniauth.rb having been loaded.

I encountered this while trying to use the omniauth-cas gem. I was going to submit a patch to that gem, but realized this would potentially affect all gems with omniauth as a dependency, so it makes more sense to do it here.
