### PR TITLE
Add the expected default options argument to the to_hash method.

### DIFF
--- a/lib/omniauth/auth_hash.rb
+++ b/lib/omniauth/auth_hash.rb
@@ -44,7 +44,7 @@ module OmniAuth
       end
       alias_method :valid?, :name?
 
-      def to_hash
+      def to_hash(options = {})
         hash = super
         hash['name'] ||= name
         hash


### PR DESCRIPTION
Gets specs to green.
