### PR TITLE
Abstracting the session storage mechanism

### DIFF
--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -15,6 +15,7 @@ module OmniAuth
   autoload :Form,     'omniauth/form'
   autoload :AuthHash, 'omniauth/auth_hash'
   autoload :FailureEndpoint, 'omniauth/failure_endpoint'
+  autoload :SessionStore, 'omniauth/session_store'
 
   def self.strategies
     @strategies ||= []
@@ -39,6 +40,7 @@ module OmniAuth
         :before_callback_phase  => nil,
         :before_options_phase   => nil,
         :form_css => Form::DEFAULT_CSS,
+        :request_store => OmniAuth::SessionStore,
         :test_mode => false,
         :logger => default_logger,
         :allowed_request_methods => [:get, :post],
@@ -114,7 +116,16 @@ module OmniAuth
     end
 
     attr_writer   :on_failure, :before_callback_phase, :before_options_phase, :before_request_phase
-    attr_accessor :failure_raise_out_environments, :path_prefix, :allowed_request_methods, :form_css, :test_mode, :mock_auth, :full_host, :camelizations, :logger
+    attr_accessor :failure_raise_out_environments,
+                  :path_prefix,
+                  :allowed_request_methods,
+                  :form_css,
+                  :test_mode,
+                  :mock_auth,
+                  :full_host,
+                  :camelizations,
+                  :logger,
+                  :request_store
   end
 
   def self.config

--- a/lib/omniauth/auth_hash.rb
+++ b/lib/omniauth/auth_hash.rb
@@ -44,7 +44,7 @@ module OmniAuth
       end
       alias_method :valid?, :name?
 
-      def to_hash
+      def to_hash(options = {})
         hash = super
         hash['name'] ||= name
         hash

--- a/lib/omniauth/session_store.rb
+++ b/lib/omniauth/session_store.rb
@@ -1,0 +1,32 @@
+module OmniAuth
+  class SessionStore
+    attr_reader :env
+
+    def self.call(env)
+      new(env)
+    end
+
+    def initialize(env)
+      @env = env
+    end
+
+    def []= (key,value)
+      session[key] = value
+    end
+
+    def [] (key)
+      session[key]
+    end
+
+    def delete (key)
+      session.delete(key)
+    end
+
+    protected
+
+    def session
+      @env['rack.session']
+    end
+
+  end
+end

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -146,7 +146,7 @@ module OmniAuth
     end
 
     def inspect
-      "#<#{self.class.to_s}>"
+      "#<#{self.class}>"
     end
 
     # Direct access to the OmniAuth logger, automatically prefixed
@@ -467,7 +467,7 @@ module OmniAuth
       env['omniauth.error.strategy'] = self
 
       if exception
-        log :error, "Authentication failure! #{message_key}: #{exception.class.to_s}, #{exception.message}"
+        log :error, "Authentication failure! #{message_key}: #{exception.class}, #{exception.message}"
       else
         log :error, "Authentication failure! #{message_key} encountered."
       end

--- a/spec/omniauth/session_store_spec.rb
+++ b/spec/omniauth/session_store_spec.rb
@@ -1,0 +1,28 @@
+require 'helper'
+
+def mock_env
+  {
+    'rack.session' => {}
+  }
+end
+
+describe OmniAuth::SessionStore do
+  describe 'adding to the session' do
+    subject { OmniAuth::SessionStore.new(mock_env) }
+    let(:mock_params) { {"uid"=> "ID", "name" => "Paul"} }
+    it 'can store items in the session' do
+      subject["omniauth.params"]= mock_params
+      expect(subject["omniauth.params"]).to eq(mock_params)
+    end
+  end
+  
+  describe 'delete from session' do
+    subject { OmniAuth::SessionStore.new(mock_env) }
+    let(:mock_params) { {"uid"=> "ID", "name" => "Paul"} }
+    it 'can delete items from the session' do
+      subject["omniauth.params"]= mock_params
+      subject.delete("omniauth.params")
+      expect(subject["omniauth.params"]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
### What am I

We had a condition at ThinkThroughMath where an incoming request to the request phase included a rather large set of request params. This was causing a cookie overflow to occur. We do not want to incur the overhead of moving away from our cookie session_store. So I abstracted the session process in OmniAuth to accept a storage adapter. I have added the rack.session process back as the SessionStore adapter and create on for redis here https://github.com/ninjapanzer/omniauth-redis-store which hooks into the config process to allow me to define the redis client I want to use. After requiring the adapter config looks a little like this:

```
require 'omniauth-redis-store'

OmniAuth.config.request_store = OmniAuth::RedisStore
OmniAuth.config.redis = Redis::Namespace.new('OmniAuth', :redis => REDIS)
```
### The adapter spec

Adapters implement a Hash like interface with [], []=, and delete methods

I also moved the session method out of the strategy and into the concern of the storage adapter
