### PR TITLE
Don't add nil name attribute to InfoHash

### DIFF
--- a/lib/omniauth/auth_hash.rb
+++ b/lib/omniauth/auth_hash.rb
@@ -46,7 +46,8 @@ module OmniAuth
 
       def to_hash
         hash = super
-        hash['name'] ||= name
+        n = name
+        hash['name'] ||= n if n
         hash
       end
     end


### PR DESCRIPTION
Currently `InfoHash#to_hash` always adds `name` attribute to the resulting hash, even if it is nil. 

PR fixes this behavior by adding only non-nil name.
