### PR TITLE
Treat dynamic request_path like callback_path

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -377,7 +377,10 @@ module OmniAuth
     end
 
     def request_path
-      options[:request_path].is_a?(String) ? options[:request_path] : "#{path_prefix}/#{name}"
+      path = options[:request_path] if options[:request_path].is_a?(String)
+      path ||= current_path if options[:request_path].respond_to?(:call) && options[:request_path].call(env)
+      path ||= "#{path_prefix}/#{name}"
+      path
     end
 
     def callback_path

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -431,6 +431,15 @@ describe OmniAuth::Strategy do
         expect { strategy_instance.call(make_env('/auth/bish/bosh/callback')) }.to raise_error('Callback Phase')
         expect(strategy_instance.callback_path).to eq('/auth/bish/bosh/callback')
       end
+
+      it 'correctly reports the request path when the custom request path evaluator is truthy' do
+        strategy_instance = ExampleStrategy.new(app,
+                                                :request_path => lambda { |env| env['PATH_INFO'] == '/auth/bish/bosh' }
+        )
+
+        expect { strategy_instance.call(make_env('/auth/bish/bosh')) }.to raise_error('Request Phase')
+        expect(strategy_instance.request_path).to eq('/auth/bish/bosh')
+      end
     end
 
     context 'custom paths' do


### PR DESCRIPTION
I'm using dynamic paths (see https://github.com/intridea/omniauth/issues/585 ).

The request_path method was not doing the right thing when a proc was passed to options[:request_path]. This is a simple fix for that.
