### PR TITLE
Performance benchmarks for middleware call

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem 'yard'
 group :development do
   gem 'kramdown'
   gem 'pry'
+  gem 'benchmark-ips'
+  gem 'memory_profiler'
 end
 
 group :test do

--- a/Rakefile
+++ b/Rakefile
@@ -15,3 +15,38 @@ rescue LoadError
 end
 
 task :default => [:spec, :rubocop]
+
+namespace :perf do
+  task :setup do
+    require 'omniauth'
+    require 'rack/test'
+    app = Rack::Builder.new do |b|
+      b.use Rack::Session::Cookie, :secret => 'abc123'
+      b.use OmniAuth::Strategies::Developer
+      b.run lambda { |_env| [200, {}, ['Not Found']] }
+    end.to_app
+    @app = Rack::MockRequest.new(app)
+
+    def call_app(path = ENV['GET_PATH'] || '/')
+      result = @app.get(path)
+      fail "Did not succeed #{result.body}" unless result.status == 200
+      result
+    end
+  end
+
+  task :ips => :setup do
+    require 'benchmark/ips'
+    Benchmark.ips do |x|
+      x.report('ips') { call_app }
+    end
+  end
+
+  task :mem => :setup do
+    require 'memory_profiler'
+    num = Integer(ENV['CNT'] || 1)
+    report = MemoryProfiler.report do
+      num.times { call_app }
+    end
+    report.pretty_print
+  end
+end


### PR DESCRIPTION
Isolated rack performance tests for the omniauth middleware call.

```
# See maximum iterations per second of middleware
$ bundle exec rake perf:ips

# Profiles memory usage of app called CNT times (default is 1)
$ bundle exec rake perf:mem CNT=100
```

You can configure the path requests are going to with `GET_PATH=/whatever`
