### PR TITLE
simplifies OmniAuth::Strategy.default_options

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -21,9 +21,8 @@ module OmniAuth
       # Returns an inherited set of default options set at the class-level
       # for each strategy.
       def default_options
-        return @default_options if instance_variable_defined?(:@default_options) && @default_options
-        existing = superclass.respond_to?(:default_options) ? superclass.default_options : {}
-        @default_options = OmniAuth::Strategy::Options.new(existing)
+        existing = superclass.default_options if superclass.respond_to?(:default_options)
+        @default_options ||= OmniAuth::Strategy::Options.new(existing)
       end
 
       # This allows for more declarative subclassing of strategies by allowing


### PR DESCRIPTION
I noticed that OmniAuth::Strategy::Options inherits from Hashie::Mash, meaning that it will initialize even if what you pass in is nil. Then, memoizing default_options with the ||= syntax achieves the same result as the return. 

I would greatly appreciate any feedback.

Thanks :)
Rae
