### PR TITLE
Pass through test_mode with another request method

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -257,7 +257,7 @@ module OmniAuth
     # in the event that OmniAuth has been configured to be
     # in test mode.
     def mock_call!(*)
-      return mock_request_call if on_request_path?
+      return mock_request_call if on_request_path? && OmniAuth.config.allowed_request_methods.include?(request.request_method.downcase.to_sym)
       return mock_callback_call if on_callback_path?
       call_app!
     end

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -560,6 +560,11 @@ describe OmniAuth::Strategy do
         expect(response[1]['Location']).to eq('/auth/test/callback')
       end
 
+      it "doesn't short circuit the request if request method is not allowed" do
+        response = strategy.call(make_env('/auth/test', 'REQUEST_METHOD' => 'DESTROY'))
+        expect(response[0]).to eq(404)
+      end
+
       it 'is case insensitive on request path' do
         expect(strategy.call(make_env('/AUTH/Test'))[0]).to eq(302)
       end


### PR DESCRIPTION
Hello,
In one of my rails app, I use Omniauth with multiple providers.
For each one, I can disconnect by calling a DELETE on `auth/:provider`

```
GET|POST /auth/:provider(.:format)            identities#passthru
GET|POST /auth/:provider/callback(.:format)   identities#callback 
DELETE   /auth/:provider(.:format)            identities#destroy
```

It works fine except on `test_mode`, where destroy requests are mapped as request phases.
