### PR TITLE
Adding Ruby 2.2 to the Travis CI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+  - 2.2
   - jruby-18mode
   - jruby-19mode
   - jruby-head


### PR DESCRIPTION
Won't pass until #784 is merged.
