### PR TITLE
Sets omniauth.headers on the request phase

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -199,6 +199,8 @@ module OmniAuth
       log :info, 'Request phase initiated.'
       # store query params from the request url, extracted in the callback_phase
       session['omniauth.params'] = request.GET
+      # store query headers from the request url, extracted in the callback_phase
+      session['omniauth.headers'] = headers
       OmniAuth.config.before_request_phase.call(env) if OmniAuth.config.before_request_phase
       if options.form.respond_to?(:call)
         log :info, 'Rendering form from supplied Rack endpoint.'
@@ -223,6 +225,7 @@ module OmniAuth
       @env['omniauth.origin'] = session.delete('omniauth.origin')
       @env['omniauth.origin'] = nil if env['omniauth.origin'] == ''
       @env['omniauth.params'] = session.delete('omniauth.params') || {}
+      @env['omniauth.headers'] = session.delete('omniauth.headers') || {}
       OmniAuth.config.before_callback_phase.call(@env) if OmniAuth.config.before_callback_phase
       callback_phase
     end
@@ -266,6 +269,7 @@ module OmniAuth
       setup_phase
 
       session['omniauth.params'] = request.GET
+      session['omniauth.headers'] = headers
       OmniAuth.config.before_request_phase.call(env) if OmniAuth.config.before_request_phase
       if request.params['origin']
         @env['rack.session']['omniauth.origin'] = request.params['origin']
@@ -286,6 +290,7 @@ module OmniAuth
       else
         @env['omniauth.auth'] = mocked_auth
         @env['omniauth.params'] = session.delete('omniauth.params') || {}
+        @env['omniauth.headers'] = session.delete('omniauth.headers') || {}
         OmniAuth.config.before_callback_phase.call(@env) if OmniAuth.config.before_callback_phase
         call_app!
       end
@@ -497,6 +502,11 @@ module OmniAuth
         request.env['HTTP_X_FORWARDED_SCHEME'] == 'https' ||
         (request.env['HTTP_X_FORWARDED_PROTO'] && request.env['HTTP_X_FORWARDED_PROTO'].split(',')[0] == 'https') ||
         request.env['rack.url_scheme'] == 'https'
+    end
+
+    def headers
+      headers = env.select { |key, value| key.start_with? 'HTTP_' }
+      Hash[headers.map { |key, value| [key.sub(/^HTTP_/, ''), value] }]
     end
   end
 end

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -505,7 +505,7 @@ module OmniAuth
     end
 
     def headers
-      headers = env.select { |key, value| key.start_with? 'HTTP_' }
+      headers = env.select { |key, _value| key.start_with? 'HTTP_' }
       Hash[headers.map { |key, value| [key.sub(/^HTTP_/, ''), value] }]
     end
   end

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -706,7 +706,7 @@ describe OmniAuth::Strategy do
       it 'sets omniauth.headers on the request phase' do
         OmniAuth.config.mock_auth[:test] = {}
 
-        strategy.call(make_env('/auth/test', { 'HTTP_FOO' => 'bar' }))
+        strategy.call(make_env('/auth/test', 'HTTP_FOO' => 'bar'))
         expect(strategy.env['rack.session']['omniauth.headers']).to eq('FOO' => 'bar')
       end
 

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -703,6 +703,13 @@ describe OmniAuth::Strategy do
         expect(strategy.env['rack.session']['omniauth.params']).to eq({})
       end
 
+      it 'sets omniauth.headers on the request phase' do
+        OmniAuth.config.mock_auth[:test] = {}
+
+        strategy.call(make_env('/auth/test', { 'HTTP_FOO' => 'bar' }))
+        expect(strategy.env['rack.session']['omniauth.headers']).to eq('FOO' => 'bar')
+      end
+
       it 'executes request hook on the request phase' do
         OmniAuth.config.mock_auth[:test] = {}
         OmniAuth.config.before_request_phase do |env|


### PR DESCRIPTION
Add `env['omniauth.headers']` which is a hash with header values on the request phase. Closes #804 
