### PR TITLE
Protect request phase against CSRF when Rails is used.

### DIFF
--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -2,6 +2,8 @@ require 'rack'
 require 'singleton'
 require 'logger'
 
+require 'omniauth/railtie' if defined?(Rails)
+
 module OmniAuth
   class Error < StandardError; end
 

--- a/lib/omniauth/railtie.rb
+++ b/lib/omniauth/railtie.rb
@@ -1,0 +1,15 @@
+require 'omniauth/request_forgery_protection'
+
+module OmniAuth
+  class Railtie < Rails::Railtie
+    initializer 'omniauth' do
+      OmniAuth.config.logger = Rails.logger
+
+      # Protect request phase against CSRF.
+      OmniAuth.config.allowed_request_methods = [:post]
+      OmniAuth.config.before_request_phase do |env|
+        RequestForgeryProtection.new(env).call
+      end
+    end
+  end
+end

--- a/lib/omniauth/request_forgery_protection.rb
+++ b/lib/omniauth/request_forgery_protection.rb
@@ -1,0 +1,67 @@
+require 'action_dispatch/http/request'
+
+module OmniAuth
+  # Based on ActionController::RequestForgeryProtection.
+
+  class RequestForgeryProtection
+    def initialize(env)
+      @env = env
+    end
+
+    def request
+      @_request ||= ActionDispatch::Request.new(@env)
+    end
+
+    def session
+      request.session
+    end
+
+    def reset_session
+      request.reset_session
+    end
+
+    def params
+      @_params ||= request.parameters
+    end
+
+    def call
+      verify_authenticity_token
+    end
+
+    def verify_authenticity_token
+      return if verified_request?
+
+      OmniAuth.logger.warn "Can't verify CSRF token authenticity" if OmniAuth.logger
+      handle_unverified_request
+    end
+
+  private
+
+    def protect_against_forgery?
+      ::ApplicationController.allow_forgery_protection
+    end
+
+    def request_forgery_protection_token
+      ::ApplicationController.request_forgery_protection_token
+    end
+
+    def forgery_protection_strategy
+      ::ApplicationController.forgery_protection_strategy
+    end
+
+    def verified_request?
+      !protect_against_forgery? || request.get? || request.head? ||
+        form_authenticity_token == params[request_forgery_protection_token] ||
+        form_authenticity_token == request.headers['X-CSRF-Token']
+    end
+
+    def handle_unverified_request
+      forgery_protection_strategy.new(self).handle_unverified_request
+    end
+
+    # Sets the token value for the current session.
+    def form_authenticity_token
+      session[:_csrf_token] ||= SecureRandom.base64(32)
+    end
+  end
+end


### PR DESCRIPTION
TL;DR, as of 2020-03-07: 

> Please note: there is currently a CSRF vulnerability which affects OmniAuth (designated [CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284)) that requires mitigation at the application level. More details on how to do this can be found on the [Wiki](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284).

Original issue description:

---

The request phase in OmniAuth is currently vulnerable to Cross-Site Request Forgery, which allows an attacker to easily gain full access to a user's account on a site that uses OmniAuth, when used in combination with another CSRF vulnerability on the side of a connected OAuth provider.

This vulnerability was reported to us (GitLab) by Mohamed Abdelbaset Elnoby (@symbiansymoh), a Senior Information Security Analyst at [Seekurity.com](http://seekurity.com), on April 23rd. On April 24th, we reported it to the OmniAuth team via email. On May 14th, we [merged our patch](https://gitlab.com/gitlab-org/gitlab-ce/commit/c2ee828c19cb245809647428334b8ef215536a0d) into the public GitLab repository.

Mr. Elnoby also gave us an example of an OAuth provider that had the CSRF vulnerability on their side that is needed to make this attack "weaponizable". The vulnerability has been reported to them.

The below description of the issue is written from GitLab’s perspective.

> Connecting the GitLab account to an OAuth provider like Google works like this:
> 1. User visits https://gitlab.com/users/auth/google
> 2. User is redirected to a page on Google
> 3. Google checks if the user is logged in
> 4. If the user is logged in, Google checks if the user has authorized the GitLab.com application to use their Google account
> 5. If the user has authorized the GitLab.com application to use their Google account, Google redirects back to GitLab
> 6. GitLab adds the Google account to the GitLab account as an alternate identity, which means the Google account can be used to log into the GitLab account.
> 
> This is all very straightforward, and works as expected.
> 
> Note that if the Google user has already authorized the GitLab.com application to use their Google account, there is no user action needed to link the two accounts, apart from the initial https://gitlab.com/users/auth/google visit.
> 
> This means that if you can get a person who 1) is signed into Google, 2) has authorized the GitLab.com application to use it, and 3) is signed into GitLab.com, to visit https://gitlab.com/users/auth/google, their account will be linked to the Google account without any further interaction, and without any feedback to the user.
> 
> This is not a big deal if the signed in Google account belongs to the GitLab user themselves, but it is if the user is somehow signed into Google using an account belonging to an attacker. In this scenario, the GitLab account would be linked to the attacker's Google account, and the GitLab user would be none the wiser.
> 
> And let it just so be the case that that iss possible with _Redacted_: there exists a vulnerability on their side that allows an attacker to log into _Redacted_ using CSRF, which means that if a user visits a specially crafted page, they will end up being logged into _Redacted_ as the attacker.
> 
> Combining this with the described GitLab.com flow, forcing the victim to visit that specially crafted page, and directly after that, forcing them to visit https://gitlab.com/users/auth/redacted (by using an iframe, for example), will give the attacker full control over the victim's GitLab account. "Forcing them" can be as simple as sending them a link over email and getting them to click it.

To actually use the POST method rather than GET so the CSRF token is sent along, we have changed our links to the auth path from:

``` ruby
link_to "Log in with #{provider}", omniauth_authorize_path(:user, provider)
```

to:

``` ruby
link_to "Log in with #{provider}", omniauth_authorize_path(:user, provider), method: :post
```

Note that the current implementation is very specific to Rails. It needs to be, as far as I can see, since the CSRF protection needs to use the web framework’s authenticity token. 

I suggest deprecating `OmniAuth.config.allowed_request_methods` and only allowing `:post` from now on, but I haven't made that change yet since I think it warrants more discussion.

People that use OmniAuth with Rails will need to change the `link_to` helpers and `<form>` tags in their own code to use `POST` instead of `GET`, 
so I’m afraid this is a breaking change and can’t just go in a patch release, in SemVer terms.

cc @sferik 
