### PR TITLE
non-raise-out failure redirects with params from request

### DIFF
--- a/lib/omniauth/failure_endpoint.rb
+++ b/lib/omniauth/failure_endpoint.rb
@@ -27,7 +27,7 @@ module OmniAuth
 
     def redirect_to_failure
       message_key = env['omniauth.error.type']
-      new_path = "#{env['SCRIPT_NAME']}#{OmniAuth.config.path_prefix}/failure?message=#{message_key}#{origin_query_param}#{strategy_name_query_param}"
+      new_path = "#{env['SCRIPT_NAME']}#{OmniAuth.config.path_prefix}/failure?message=#{message_key}#{origin_query_param}#{strategy_name_query_param}#{request_params_query_param}"
       Rack::Response.new(['302 Moved'], 302, 'Location' => new_path).finish
     end
 
@@ -39,6 +39,11 @@ module OmniAuth
     def origin_query_param
       return '' unless env['omniauth.origin']
       "&origin=#{Rack::Utils.escape(env['omniauth.origin'])}"
+    end
+
+    def request_params_query_param
+      return '' unless env['omniauth.params']
+      return "&#{URI.encode_www_form(env['omniauth.params'])}"
     end
   end
 end

--- a/lib/omniauth/failure_endpoint.rb
+++ b/lib/omniauth/failure_endpoint.rb
@@ -43,7 +43,7 @@ module OmniAuth
 
     def request_params_query_param
       return '' unless env['omniauth.params']
-      return "&#{URI.encode_www_form(env['omniauth.params'])}"
+      return "&#{Rack::Utils.build_query(env['omniauth.params'])}"
     end
   end
 end

--- a/spec/omniauth/failure_endpoint_spec.rb
+++ b/spec/omniauth/failure_endpoint_spec.rb
@@ -54,5 +54,11 @@ describe OmniAuth::FailureEndpoint do
       _, head, = *subject.call(env)
       expect(head['Location']).to be_include('&origin=%2Forigin-example')
     end
+
+    it 'includes the params from request if one is provided' do
+      env.merge! 'omniauth.params' => {'foo' => 'bar'}
+       _, head, = *subject.call(env)
+      expect(head['Location']).to be_include('foo=bar')
+    end
   end
 end


### PR DESCRIPTION
Failure endpoint redirects with the params from env['omniauth.params']
