### PR TITLE
update broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Constraint][pvc] with two digits of precision. For example:
     spec.add_dependency 'omniauth', '~> 1.0'
 
 [semver]: http://semver.org/
-[pvc]: http://docs.rubygems.org/read/chapter/16#page74
+[pvc]: http://guides.rubygems.org/patterns/#pessimistic-version-constraint
 
 ## License
 Copyright (c) 2010-2013 Michael Bleigh and Intridea, Inc. See [LICENSE][] for


### PR DESCRIPTION
update broken link to rubygems.org for Pessimistic Version Constraint at end of README.md
