### PR TITLE
Added check whether ancestor method is a Proc

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+Please complete all sections.
+
+### Configuration
+
+- Provider Gem: `omniauth-*`
+- Ruby Version: ``
+- Framework: ``
+- Platform: ``
+
+### Expected Behavior
+
+Tell us what should happen.
+
+### Actual Behavior
+
+Tell us what happens instead.
+
+### Steps to Reproduce
+
+Please list all steps to reproduce the issue.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 Lint/HandleExceptions:
   Enabled: false
 
+Metrics/BlockLength:
+  Enabled: false
+
 Metrics/BlockNesting:
   Max: 2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ language: ruby
 rvm:
   - jruby-19mode
   - jruby-9000
-  - 1.9.3
-  - 2.0.0
-  - 2.1.10
-  - 2.2.5
+  - 1.9.3 # EOL
+  - 2.0.0 # EOL
+  - 2.1.10 # EOL Soon
+  - 2.2.6
   - 2.3.3
   - 2.4.0
   - jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,7 @@ env:
     - JRUBY_OPTS="$JRUBY_OPTS --debug"
 language: ruby
 rvm:
-  - jruby-19mode
   - jruby-9000
-  - 1.9.3 # EOL
-  - 2.0.0 # EOL
   - 2.1.10 # EOL Soon
   - 2.2.6
   - 2.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 bundler_args: --without development
-before_install: gem install bundler
+before_install: gem update bundler
 cache: bundler
 env:
   global:
@@ -13,14 +13,13 @@ rvm:
   - 2.0.0
   - 2.1.10
   - 2.2.5
-  - 2.3.1
+  - 2.3.3
+  - 2.4.0
   - jruby-head
-  - rbx
   - ruby-head
 matrix:
   allow_failures:
     - rvm: jruby-head
-    - rvm: rbx
     - rvm: ruby-head
   fast_finish: true
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ language: ruby
 rvm:
   - jruby-19mode
   - jruby-9000
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.10

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,9 @@ gem 'rake', '>= 12.0'
 gem 'yard', '>= 0.9'
 
 group :development do
+  gem 'benchmark-ips'
   gem 'kramdown'
+  gem 'memory_profiler'
   gem 'pry'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,11 +14,11 @@ group :test do
   gem 'hashie', '~> 2.0.5', :platforms => [:jruby_18, :ruby_18]
   gem 'json', '~> 1.8', :platforms => [:jruby_18, :jruby_19, :ruby_18, :ruby_19]
   gem 'mime-types', '~> 1.25', :platforms => [:jruby_18, :ruby_18]
-  gem 'rack-test'
   gem 'rack', '~> 1.0', :platforms => [:jruby_18, :jruby_19, :ruby_18, :ruby_19, :ruby_20, :ruby_21]
+  gem 'rack-test'
   gem 'rest-client', '~> 1.6.0', :platforms => [:jruby_18, :ruby_18]
   gem 'rspec', '~> 3.0'
-  gem 'rubocop', '>= 0.25', :platforms => [:ruby_20, :ruby_21, :ruby_22]
+  gem 'rubocop', '>= 0.25', :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
   gem 'simplecov', '>= 0.9'
   gem 'tins', '~> 1.6.0', :platforms => [:jruby_18, :jruby_19, :ruby_18, :ruby_19]
 end

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 
 group :test do
   gem 'coveralls', :require => false
-  gem 'hashie', '~> 3.5.0', :platforms => [:jruby_18]
+  gem 'hashie', '>= 3.4.6', '< 3.6.0', :platforms => [:jruby_18]
   gem 'json', '~> 2.0.3', :platforms => [:jruby_18, :jruby_19, :ruby_19]
   gem 'mime-types', '~> 3.1', :platforms => [:jruby_18]
   gem 'rack', '>= 1.6.2', :platforms => [:jruby_18, :jruby_19, :ruby_19, :ruby_20, :ruby_21]

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'jruby-openssl', '>= 0.6', :platforms => :jruby
-gem 'rake', '~> 10.5'
-gem 'yard'
+gem 'jruby-openssl', '~> 0.9.19', :platforms => :jruby
+gem 'rake', '>= 12.0'
+gem 'yard', '>= 0.9'
 
 group :development do
   gem 'kramdown'
@@ -10,16 +10,16 @@ group :development do
 end
 
 group :test do
-  gem 'hashie', '~> 2.0.5', :platforms => [:jruby_18]
-  gem 'json', '~> 1.8', :platforms => [:jruby_18, :jruby_19, :ruby_19]
-  gem 'mime-types', '~> 1.25', :platforms => [:jruby_18]
+  gem 'hashie', '~> 3.5.0', :platforms => [:jruby_18]
+  gem 'json', '~> 2.0.3', :platforms => [:jruby_18, :jruby_19, :ruby_19]
+  gem 'mime-types', '~> 3.1', :platforms => [:jruby_18]
   gem 'rack', '>= 1.6.2', :platforms => [:jruby_18, :jruby_19, :ruby_19, :ruby_20, :ruby_21]
   gem 'rack-test'
-  gem 'rest-client', '~> 1.8.0', :platforms => [:jruby_18]
+  gem 'rest-client', '~> 2.0.0', :platforms => [:jruby_18]
   gem 'rspec', '~> 3.0'
-  gem 'rubocop', '>= 0.25', :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
-  gem 'simplecov', '>= 0.9'
-  gem 'tins', '~> 1.6.0', :platforms => [:jruby_18, :jruby_19, :ruby_19]
+  gem 'rubocop', '>= 0.47', :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
+  gem 'simplecov', '>= 0.13'
+  gem 'tins', '~> 1.13.0', :platforms => [:jruby_18, :jruby_19, :ruby_19]
 end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'rack', '>= 1.6.2', :platforms => [:jruby_18, :jruby_19, :ruby_19, :ruby_20, :ruby_21]
   gem 'rack-test'
   gem 'rest-client', '~> 2.0.0', :platforms => [:jruby_18]
-  gem 'rspec', '~> 3.0'
+  gem 'rspec', '~> 3.5.0'
   gem 'rubocop', '>= 0.47', :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
   gem 'simplecov', '>= 0.13'
   gem 'tins', '~> 1.13.0', :platforms => [:jruby_18, :jruby_19, :ruby_19]

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'hashie', '~> 2.0.5', :platforms => [:jruby_18]
   gem 'json', '~> 1.8', :platforms => [:jruby_18, :jruby_19, :ruby_19]
   gem 'mime-types', '~> 1.25', :platforms => [:jruby_18]
-  gem 'rack', '~> 1.0', :platforms => [:jruby_18, :jruby_19, :ruby_19, :ruby_20, :ruby_21]
+  gem 'rack', '>= 1.6.2', :platforms => [:jruby_18, :jruby_19, :ruby_19, :ruby_20, :ruby_21]
   gem 'rack-test'
   gem 'rest-client', '~> 1.6.0', :platforms => [:jruby_18]
   gem 'rspec', '~> 3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'jruby-openssl', :platforms => :jruby
+gem 'jruby-openssl', '>= 0.6', :platforms => :jruby
 gem 'rake', '~> 10.5'
 gem 'yard'
 
@@ -15,7 +15,7 @@ group :test do
   gem 'mime-types', '~> 1.25', :platforms => [:jruby_18]
   gem 'rack', '>= 1.6.2', :platforms => [:jruby_18, :jruby_19, :ruby_19, :ruby_20, :ruby_21]
   gem 'rack-test'
-  gem 'rest-client', '~> 1.6.0', :platforms => [:jruby_18]
+  gem 'rest-client', '~> 1.8.0', :platforms => [:jruby_18]
   gem 'rspec', '~> 3.0'
   gem 'rubocop', '>= 0.25', :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
   gem 'simplecov', '>= 0.9'

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :development do
 end
 
 group :test do
-  gem 'coveralls'
   gem 'hashie', '~> 2.0.5', :platforms => [:jruby_18, :ruby_18]
   gem 'json', '~> 1.8', :platforms => [:jruby_18, :jruby_19, :ruby_18, :ruby_19]
   gem 'mime-types', '~> 1.25', :platforms => [:jruby_18, :ruby_18]

--- a/Gemfile
+++ b/Gemfile
@@ -10,16 +10,16 @@ group :development do
 end
 
 group :test do
-  gem 'hashie', '~> 2.0.5', :platforms => [:jruby_18, :ruby_18]
-  gem 'json', '~> 1.8', :platforms => [:jruby_18, :jruby_19, :ruby_18, :ruby_19]
-  gem 'mime-types', '~> 1.25', :platforms => [:jruby_18, :ruby_18]
-  gem 'rack', '~> 1.0', :platforms => [:jruby_18, :jruby_19, :ruby_18, :ruby_19, :ruby_20, :ruby_21]
+  gem 'hashie', '~> 2.0.5', :platforms => [:jruby_18]
+  gem 'json', '~> 1.8', :platforms => [:jruby_18, :jruby_19, :ruby_19]
+  gem 'mime-types', '~> 1.25', :platforms => [:jruby_18]
+  gem 'rack', '~> 1.0', :platforms => [:jruby_18, :jruby_19, :ruby_19, :ruby_20, :ruby_21]
   gem 'rack-test'
-  gem 'rest-client', '~> 1.6.0', :platforms => [:jruby_18, :ruby_18]
+  gem 'rest-client', '~> 1.6.0', :platforms => [:jruby_18]
   gem 'rspec', '~> 3.0'
   gem 'rubocop', '>= 0.25', :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
   gem 'simplecov', '>= 0.9'
-  gem 'tins', '~> 1.6.0', :platforms => [:jruby_18, :jruby_19, :ruby_18, :ruby_19]
+  gem 'tins', '~> 1.6.0', :platforms => [:jruby_18, :jruby_19, :ruby_19]
 end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :test do
   gem 'rest-client', '~> 2.0.0', :platforms => [:jruby_18]
   gem 'rspec', '~> 3.5.0'
   gem 'rubocop', '>= 0.47', :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
-  gem 'simplecov', '>= 0.13'
   gem 'tins', '~> 1.13.0', :platforms => [:jruby_18, :jruby_19, :ruby_19]
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :development do
 end
 
 group :test do
+  gem 'coveralls', :require => false
   gem 'hashie', '~> 3.5.0', :platforms => [:jruby_18]
   gem 'json', '~> 2.0.3', :platforms => [:jruby_18, :jruby_19, :ruby_19]
   gem 'mime-types', '~> 3.1', :platforms => [:jruby_18]

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2013 Michael Bleigh and Intridea, Inc.
+Copyright (c) 2010-2017 Michael Bleigh and Intridea, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -122,6 +122,36 @@ environment information on the callback request. It is entirely up to
 you how you want to implement the particulars of your application's
 authentication flow.
 
+## Integrating OmniAuth Into Your Rails API
+The following middleware are (by default) included for session management in
+Rails applications. When using OmniAuth with a Rails API, you'll need to add 
+one of these required middleware back in:
+
+- `ActionDispatch::Session::CacheStore`
+- `ActionDispatch::Session::CookieStore`
+- `ActionDispatch::Session::MemCacheStore`
+
+The trick to adding these back in is that, by default, they are passed 
+`session_options` when added (including the session key), so you can't just add 
+a `session_store.rb` initializer, add `use ActionDispatch::Session::CookieStore` 
+and have sessions functioning as normal.
+
+To be clear: sessions may work, but your session options will be ignored 
+(i.e the session key will default to `_session_id`).  Instead of the 
+initializer, you'll have to set the relevant options somewhere
+before your middleware is built (like `application.rb`) and pass them to your 
+preferred middleware, like this:
+
+**application.rb:**
+
+```ruby
+config.session_store :cookie_store, key: '_interslice_session'
+config.middleware.use ActionDispatch::Cookies # Required for all session management
+config.middleware.use ActionDispatch::Session::CookieStore, config.session_options
+```
+
+(Thanks @mltsy)
+
 ## Logging
 OmniAuth supports a configurable logger. By default, OmniAuth will log
 to `STDOUT` but you can configure this using `OmniAuth.config.logger`:

--- a/README.md
+++ b/README.md
@@ -13,11 +13,6 @@
 [codeclimate]: https://codeclimate.com/github/omniauth/omniauth
 [coveralls]: https://coveralls.io/r/omniauth/omniauth
 
-**OmniAuth 1.0 has several breaking changes from version 0.x. You can set
-the dependency to `~> 0.3.2` if you do not wish to make the more difficult
-upgrade. See [the wiki](https://github.com/omniauth/omniauth/wiki/Upgrading-to-1.0)
-for more information.**
-
 ## An Introduction
 OmniAuth is a library that standardizes multi-provider authentication for
 web applications. It was created to be powerful, flexible, and do as
@@ -143,7 +138,7 @@ your first stop if you are wondering about a more in-depth look at
 OmniAuth, how it works, and how to use it.
 
 ## Supported Ruby Versions
-OmniAuth is tested under 1.9.3, 2.0.0, 2.1.10, 2.2.5, 2.3.1, and JRuby.
+OmniAuth is tested under 2.1.10, 2.2.6, 2.3.3, 2.4.0, and JRuby.
 
 ## Versioning
 This library aims to adhere to [Semantic Versioning 2.0.0][semver]. Violations

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ your first stop if you are wondering about a more in-depth look at
 OmniAuth, how it works, and how to use it.
 
 ## Supported Ruby Versions
-OmniAuth is tested under 1.8.7, 1.9.3, 2.0.0, 2.1.10, 2.2.5, 2.3.1, and JRuby.
+OmniAuth is tested under 1.9.3, 2.0.0, 2.1.10, 2.2.5, 2.3.1, and JRuby.
 
 ## Versioning
 This library aims to adhere to [Semantic Versioning 2.0.0][semver]. Violations
@@ -161,7 +161,7 @@ Constraint][pvc] with two digits of precision. For example:
 [pvc]: http://guides.rubygems.org/patterns/#pessimistic-version-constraint
 
 ## License
-Copyright (c) 2010-2013 Michael Bleigh and Intridea, Inc. See [LICENSE][] for
+Copyright (c) 2010-2017 Michael Bleigh and Intridea, Inc. See [LICENSE][] for
 details.
 
 [license]: LICENSE.md

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Dependency Status](http://img.shields.io/gemnasium/intridea/omniauth.svg)][gemnasium]
 [![Code Climate](http://img.shields.io/codeclimate/github/intridea/omniauth.svg)][codeclimate]
 [![Coverage Status](http://img.shields.io/coveralls/intridea/omniauth.svg)][coveralls]
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/intridea/omniauth/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+[![Security](https://hakiri.io/github/omniauth/omniauth/master.svg)](https://hakiri.io/github/omniauth/omniauth/master)
 
 [gem]: https://rubygems.org/gems/omniauth
 [travis]: http://travis-ci.org/intridea/omniauth

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # OmniAuth: Standardized Multi-Provider Authentication
 
 [![Gem Version](http://img.shields.io/gem/v/omniauth.svg)][gem]
-[![Build Status](http://img.shields.io/travis/intridea/omniauth.svg)][travis]
-[![Dependency Status](http://img.shields.io/gemnasium/intridea/omniauth.svg)][gemnasium]
-[![Code Climate](http://img.shields.io/codeclimate/github/intridea/omniauth.svg)][codeclimate]
-[![Coverage Status](http://img.shields.io/coveralls/intridea/omniauth.svg)][coveralls]
+[![Build Status](http://img.shields.io/travis/omniauth/omniauth.svg)][travis]
+[![Dependency Status](http://img.shields.io/gemnasium/omniauth/omniauth.svg)][gemnasium]
+[![Code Climate](http://img.shields.io/codeclimate/github/omniauth/omniauth.svg)][codeclimate]
+[![Coverage Status](http://img.shields.io/coveralls/omniauth/omniauth.svg)][coveralls]
 [![Security](https://hakiri.io/github/omniauth/omniauth/master.svg)](https://hakiri.io/github/omniauth/omniauth/master)
 
 [gem]: https://rubygems.org/gems/omniauth
-[travis]: http://travis-ci.org/intridea/omniauth
-[gemnasium]: https://gemnasium.com/intridea/omniauth
-[codeclimate]: https://codeclimate.com/github/intridea/omniauth
-[coveralls]: https://coveralls.io/r/intridea/omniauth
+[travis]: http://travis-ci.org/omniauth/omniauth
+[gemnasium]: https://gemnasium.com/omniauth/omniauth
+[codeclimate]: https://codeclimate.com/github/omniauth/omniauth
+[coveralls]: https://coveralls.io/r/omniauth/omniauth
 
 **OmniAuth 1.0 has several breaking changes from version 0.x. You can set
 the dependency to `~> 0.3.2` if you do not wish to make the more difficult
-upgrade. See [the wiki](https://github.com/intridea/omniauth/wiki/Upgrading-to-1.0)
+upgrade. See [the wiki](https://github.com/omniauth/omniauth/wiki/Upgrading-to-1.0)
 for more information.**
 
 ## An Introduction
@@ -27,7 +27,7 @@ have been created for everything from Facebook to LDAP.
 
 In order to use OmniAuth in your applications, you will need to leverage
 one or more strategies. These strategies are generally released
-individually as RubyGems, and you can see a [community maintained list](https://github.com/intridea/omniauth/wiki/List-of-Strategies)
+individually as RubyGems, and you can see a [community maintained list](https://github.com/omniauth/omniauth/wiki/List-of-Strategies)
 on the wiki for this project.
 
 One strategy, called `Developer`, is included with OmniAuth and provides
@@ -120,7 +120,7 @@ Authentication Hash which will contain information about the just
 authenticated user including a unique id, the strategy they just used
 for authentication, and personal details such as name and email address
 as available. For an in-depth description of what the authentication
-hash might contain, see the [Auth Hash Schema wiki page](https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema).
+hash might contain, see the [Auth Hash Schema wiki page](https://github.com/omniauth/omniauth/wiki/Auth-Hash-Schema).
 
 Note that OmniAuth does not perform any actions beyond setting some
 environment information on the callback request. It is entirely up to
@@ -137,7 +137,7 @@ OmniAuth.config.logger = Rails.logger
 ```
 
 ## Resources
-The [OmniAuth Wiki](https://github.com/intridea/omniauth/wiki) has
+The [OmniAuth Wiki](https://github.com/omniauth/omniauth/wiki) has
 actively maintained in-depth documentation for OmniAuth. It should be
 your first stop if you are wondering about a more in-depth look at
 OmniAuth, how it works, and how to use it.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Constraint][pvc] with two digits of precision. For example:
     spec.add_dependency 'omniauth', '~> 1.0'
 
 [semver]: http://semver.org/
-[pvc]: http://docs.rubygems.org/read/chapter/16#page74
+[pvc]: http://guides.rubygems.org/patterns/#pessimistic-version-constraint
 
 ## License
 Copyright (c) 2010-2013 Michael Bleigh and Intridea, Inc. See [LICENSE][] for

--- a/Rakefile
+++ b/Rakefile
@@ -15,3 +15,38 @@ rescue LoadError
 end
 
 task :default => [:spec, :rubocop]
+
+namespace :perf do
+  task :setup do
+    require 'omniauth'
+    require 'rack/test'
+    app = Rack::Builder.new do |b|
+      b.use Rack::Session::Cookie, :secret => 'abc123'
+      b.use OmniAuth::Strategies::Developer
+      b.run lambda { |_env| [200, {}, ['Not Found']] }
+    end.to_app
+    @app = Rack::MockRequest.new(app)
+
+    def call_app(path = ENV['GET_PATH'] || '/')
+      result = @app.get(path)
+      raise "Did not succeed #{result.body}" unless result.status == 200
+      result
+    end
+  end
+
+  task :ips => :setup do
+    require 'benchmark/ips'
+    Benchmark.ips do |x|
+      x.report('ips') { call_app }
+    end
+  end
+
+  task :mem => :setup do
+    require 'memory_profiler'
+    num = Integer(ENV['CNT'] || 1)
+    report = MemoryProfiler.report do
+      num.times { call_app }
+    end
+    report.pretty_print
+  end
+end

--- a/lib/omniauth/auth_hash.rb
+++ b/lib/omniauth/auth_hash.rb
@@ -20,7 +20,7 @@ module OmniAuth
     end
 
     def regular_writer(key, value)
-      if key.to_s == 'info' && !value.is_a?(InfoHash)
+      if key.to_s == 'info' && value.is_a?(::Hash) && !value.is_a?(InfoHash)
         value = InfoHash.new(value)
       end
       super

--- a/lib/omniauth/auth_hash.rb
+++ b/lib/omniauth/auth_hash.rb
@@ -1,11 +1,11 @@
-require 'hashie/mash'
+require 'omniauth/key_store'
 
 module OmniAuth
   # The AuthHash is a normalized schema returned by all OmniAuth
   # strategies. It maps as much user information as the provider
   # is able to provide into the InfoHash (stored as the `'info'`
   # key).
-  class AuthHash < Hashie::Mash
+  class AuthHash < OmniAuth::KeyStore
     def self.subkey_class
       Hashie::Mash
     end
@@ -26,7 +26,7 @@ module OmniAuth
       super
     end
 
-    class InfoHash < Hashie::Mash
+    class InfoHash < OmniAuth::KeyStore
       def self.subkey_class
         Hashie::Mash
       end

--- a/lib/omniauth/form.css
+++ b/lib/omniauth/form.css
@@ -56,7 +56,7 @@ input {
 }
 
 input#identifier, input#openid_url {
-  background: url(http://openid.net/login-bg.gif) no-repeat;
+  background: url(https://openid.net/images/login-bg.gif) no-repeat;
   background-position: 0 50%;
   padding-left: 18px;
 }

--- a/lib/omniauth/key_store.rb
+++ b/lib/omniauth/key_store.rb
@@ -1,0 +1,22 @@
+require 'hashie/mash'
+
+module OmniAuth
+  # Generic helper hash that allows method access on deeply nested keys.
+  class KeyStore < ::Hashie::Mash
+    # Disables warnings on Hashie 3.5.0+ for overwritten keys
+    def self.override_logging
+      require 'hashie/version'
+      return unless Gem::Version.new(Hashie::VERSION) >= Gem::Version.new('3.5.0')
+
+      if respond_to?(:disable_warnings)
+        disable_warnings
+      else
+        define_method(:log_built_in_message) { |*| }
+        private :log_built_in_message
+      end
+    end
+
+    # Disable on loading of the class
+    override_logging
+  end
+end

--- a/lib/omniauth/key_store.rb
+++ b/lib/omniauth/key_store.rb
@@ -8,12 +8,15 @@ module OmniAuth
       require 'hashie/version'
       return unless Gem::Version.new(Hashie::VERSION) >= Gem::Version.new('3.5.0')
 
-      if respond_to?(:disable_warnings)
-        disable_warnings
-      else
-        define_method(:log_built_in_message) { |*| }
-        private :log_built_in_message
-      end
+      # if respond_to?(:disable_warnings)
+      #   disable_warnings
+      # else
+      #   define_method(:log_built_in_message) { |*| }
+      #   private :log_built_in_message
+      # end
+
+      define_method(:log_built_in_message) { |*| }
+      private :log_built_in_message
     end
 
     # Disable on loading of the class

--- a/lib/omniauth/key_store.rb
+++ b/lib/omniauth/key_store.rb
@@ -8,15 +8,12 @@ module OmniAuth
       require 'hashie/version'
       return unless Gem::Version.new(Hashie::VERSION) >= Gem::Version.new('3.5.0')
 
-      # if respond_to?(:disable_warnings)
-      #   disable_warnings
-      # else
-      #   define_method(:log_built_in_message) { |*| }
-      #   private :log_built_in_message
-      # end
-
-      define_method(:log_built_in_message) { |*| }
-      private :log_built_in_message
+      if respond_to?(:disable_warnings)
+        disable_warnings
+      else
+        define_method(:log_built_in_message) { |*| }
+        private :log_built_in_message
+      end
     end
 
     # Disable on loading of the class

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -202,8 +202,6 @@ module OmniAuth
       log :info, 'Request phase initiated.'
       # store query params from the request url, extracted in the callback_phase
       session['omniauth.params'] = request.GET
-      # store query headers from the request url, extracted in the callback_phase
-      session['omniauth.headers'] = headers
       OmniAuth.config.before_request_phase.call(env) if OmniAuth.config.before_request_phase
       if options.form.respond_to?(:call)
         log :info, 'Rendering form from supplied Rack endpoint.'
@@ -228,7 +226,6 @@ module OmniAuth
       @env['omniauth.origin'] = session.delete('omniauth.origin')
       @env['omniauth.origin'] = nil if env['omniauth.origin'] == ''
       @env['omniauth.params'] = session.delete('omniauth.params') || {}
-      @env['omniauth.headers'] = session.delete('omniauth.headers') || {}
       OmniAuth.config.before_callback_phase.call(@env) if OmniAuth.config.before_callback_phase
       callback_phase
     end
@@ -272,7 +269,6 @@ module OmniAuth
       setup_phase
 
       session['omniauth.params'] = request.GET
-      session['omniauth.headers'] = headers
       OmniAuth.config.before_request_phase.call(env) if OmniAuth.config.before_request_phase
       if request.params['origin']
         @env['rack.session']['omniauth.origin'] = request.params['origin']
@@ -288,7 +284,6 @@ module OmniAuth
       @env['omniauth.origin'] = session.delete('omniauth.origin')
       @env['omniauth.origin'] = nil if env['omniauth.origin'] == ''
       @env['omniauth.params'] = session.delete('omniauth.params') || {}
-      @env['omniauth.headers'] = session.delete('omniauth.headers') || {}
 
       mocked_auth = OmniAuth.mock_auth_for(name.to_s)
       if mocked_auth.is_a?(Symbol)
@@ -506,11 +501,6 @@ module OmniAuth
         request.env['HTTP_X_FORWARDED_SCHEME'] == 'https' ||
         (request.env['HTTP_X_FORWARDED_PROTO'] && request.env['HTTP_X_FORWARDED_PROTO'].split(',')[0] == 'https') ||
         request.env['rack.url_scheme'] == 'https'
-    end
-
-    def headers
-      headers = env.select { |key, _value| key.start_with? 'HTTP_' }
-      Hash[headers.map { |key, value| [key.sub(/^HTTP_/, ''), value] }]
     end
   end
 end

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -271,9 +271,9 @@ module OmniAuth
       session['omniauth.params'] = request.GET
       OmniAuth.config.before_request_phase.call(env) if OmniAuth.config.before_request_phase
       if request.params['origin']
-        @env['rack.session']['omniauth.origin'] = request.params['origin']
+        session['omniauth.origin'] = request.params['origin']
       elsif env['HTTP_REFERER'] && !env['HTTP_REFERER'].match(/#{request_path}$/)
-        @env['rack.session']['omniauth.origin'] = env['HTTP_REFERER']
+        session['omniauth.origin'] = env['HTTP_REFERER']
       end
 
       redirect(callback_url)

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -88,9 +88,12 @@ module OmniAuth
       end
 
       %w(uid info extra credentials).each do |fetcher|
-        class_eval <<-RUBY
+        class_eval <<-RUBY, __FILE__, __LINE__ + 1
+          attr_reader :#{fetcher}_proc
+          private :#{fetcher}_proc
+
           def #{fetcher}(&block)
-            return @#{fetcher}_proc unless block_given?
+            return #{fetcher}_proc unless block_given?
             @#{fetcher}_proc = block
           end
 

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -21,9 +21,9 @@ module OmniAuth
       # Returns an inherited set of default options set at the class-level
       # for each strategy.
       def default_options
-        return @default_options if instance_variable_defined?(:@default_options) && @default_options
+        # existing = superclass.default_options if superclass.respond_to?(:default_options)
         existing = superclass.respond_to?(:default_options) ? superclass.default_options : {}
-        @default_options = OmniAuth::Strategy::Options.new(existing)
+        @default_options ||= OmniAuth::Strategy::Options.new(existing)
       end
 
       # This allows for more declarative subclassing of strategies by allowing

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -105,7 +105,7 @@ module OmniAuth
 
       def compile_stack(ancestors, method, context)
         stack = ancestors.inject([]) do |a, ancestor|
-          a << context.instance_eval(&ancestor.send(method)) if ancestor.respond_to?(method) && ancestor.send(method)
+          a << context.instance_eval(&ancestor.send(method)) if ancestor.respond_to?(method) && ancestor.send(method).class == Proc
           a
         end
         stack.reverse!

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -1,4 +1,4 @@
-require 'hashie/mash'
+require 'omniauth/key_store'
 
 module OmniAuth
   class NoSessionError < StandardError; end
@@ -480,7 +480,7 @@ module OmniAuth
       end
     end
 
-    class Options < Hashie::Mash; end
+    class Options < OmniAuth::KeyStore; end
 
   protected
 

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -347,14 +347,9 @@ module OmniAuth
     #
     #   use MyStrategy, :skip_info => lambda{|uid| User.find_by_uid(uid)}
     def skip_info?
-      if options.skip_info?
-        if options.skip_info.respond_to?(:call)
-          return options.skip_info.call(uid)
-        else
-          return true
-        end
-      end
-      false
+      return false unless options.skip_info?
+      return true unless options.skip_info.respond_to?(:call)
+      options.skip_info.call(uid)
     end
 
     def callback_phase

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -198,7 +198,7 @@ module OmniAuth
       setup_phase
       log :info, 'Request phase initiated.'
       # store query params from the request url, extracted in the callback_phase
-      session['omniauth.params'] = request.params
+      session['omniauth.params'] = request.GET
       OmniAuth.config.before_request_phase.call(env) if OmniAuth.config.before_request_phase
       if options.form.respond_to?(:call)
         log :info, 'Rendering form from supplied Rack endpoint.'
@@ -265,7 +265,7 @@ module OmniAuth
     def mock_request_call
       setup_phase
 
-      session['omniauth.params'] = request.params
+      session['omniauth.params'] = request.GET
       OmniAuth.config.before_request_phase.call(env) if OmniAuth.config.before_request_phase
       if request.params['origin']
         @env['rack.session']['omniauth.origin'] = request.params['origin']

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -263,7 +263,7 @@ module OmniAuth
     # in the event that OmniAuth has been configured to be
     # in test mode.
     def mock_call!(*)
-      return mock_request_call if on_request_path?
+      return mock_request_call if on_request_path? && OmniAuth.config.allowed_request_methods.include?(request.request_method.downcase.to_sym)
       return mock_callback_call if on_callback_path?
       call_app!
     end

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -135,7 +135,7 @@ module OmniAuth
       @options = self.class.default_options.dup
 
       options.deep_merge!(args.pop) if args.last.is_a?(Hash)
-      options.name ||= self.class.to_s.split('::').last.downcase
+      options[:name] ||= self.class.to_s.split('::').last.downcase
 
       self.class.args.each do |arg|
         break if args.empty?
@@ -240,8 +240,8 @@ module OmniAuth
     end
 
     def on_request_path?
-      if options.request_path.respond_to?(:call)
-        options.request_path.call(env)
+      if options[:request_path].respond_to?(:call)
+        options[:request_path].call(env)
       else
         on_path?(request_path)
       end
@@ -307,7 +307,7 @@ module OmniAuth
       if options[:setup].respond_to?(:call)
         log :info, 'Setup endpoint detected, running now.'
         options[:setup].call(env)
-      elsif options.setup?
+      elsif options[:setup]
         log :info, 'Calling through to underlying application for setup.'
         setup_env = env.merge('PATH_INFO' => setup_path, 'REQUEST_METHOD' => 'GET')
         call_app!(setup_env)
@@ -448,7 +448,7 @@ module OmniAuth
     end
 
     def name
-      options.name
+      options[:name]
     end
 
     def redirect(uri)

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -287,13 +287,14 @@ module OmniAuth
       setup_phase
       @env['omniauth.origin'] = session.delete('omniauth.origin')
       @env['omniauth.origin'] = nil if env['omniauth.origin'] == ''
+      @env['omniauth.params'] = session.delete('omniauth.params') || {}
+      @env['omniauth.headers'] = session.delete('omniauth.headers') || {}
+
       mocked_auth = OmniAuth.mock_auth_for(name.to_s)
       if mocked_auth.is_a?(Symbol)
         fail!(mocked_auth)
       else
         @env['omniauth.auth'] = mocked_auth
-        @env['omniauth.params'] = session.delete('omniauth.params') || {}
-        @env['omniauth.headers'] = session.delete('omniauth.headers') || {}
         OmniAuth.config.before_callback_phase.call(@env) if OmniAuth.config.before_callback_phase
         call_app!
       end

--- a/lib/omniauth/test/strategy_test_case.rb
+++ b/lib/omniauth/test/strategy_test_case.rb
@@ -10,7 +10,7 @@ module OmniAuth
     #     include OmniAuth::Test::StrategyTestCase
     #     def strategy
     #       # return the parameters to a Rack::Builder map call:
-    #       [MyStrategy.new, :some, :configuration, :options => 'here']
+    #       [MyStrategy, :some, :configuration, :options => 'here']
     #     end
     #     setup do
     #       post '/auth/my_strategy/callback', :user => { 'name' => 'Dylan', 'id' => '445' }

--- a/lib/omniauth/version.rb
+++ b/lib/omniauth/version.rb
@@ -1,3 +1,3 @@
 module OmniAuth
-  VERSION = '1.4.0'.freeze
+  VERSION = '1.4.1'.freeze
 end

--- a/lib/omniauth/version.rb
+++ b/lib/omniauth/version.rb
@@ -1,3 +1,3 @@
 module OmniAuth
-  VERSION = '1.4.2'.freeze
+  VERSION = '1.4.3'.freeze
 end

--- a/lib/omniauth/version.rb
+++ b/lib/omniauth/version.rb
@@ -1,3 +1,3 @@
 module OmniAuth
-  VERSION = '1.3.1'.freeze
+  VERSION = '1.3.2'.freeze
 end

--- a/lib/omniauth/version.rb
+++ b/lib/omniauth/version.rb
@@ -1,3 +1,3 @@
 module OmniAuth
-  VERSION = '1.5.0'.freeze
+  VERSION = '1.6.0'.freeze
 end

--- a/lib/omniauth/version.rb
+++ b/lib/omniauth/version.rb
@@ -1,3 +1,3 @@
 module OmniAuth
-  VERSION = '1.6.0'.freeze
+  VERSION = '1.6.1'.freeze
 end

--- a/lib/omniauth/version.rb
+++ b/lib/omniauth/version.rb
@@ -1,3 +1,3 @@
 module OmniAuth
-  VERSION = '1.4.1'.freeze
+  VERSION = '1.4.2'.freeze
 end

--- a/lib/omniauth/version.rb
+++ b/lib/omniauth/version.rb
@@ -1,3 +1,3 @@
 module OmniAuth
-  VERSION = '1.3.2'.freeze
+  VERSION = '1.4.0'.freeze
 end

--- a/lib/omniauth/version.rb
+++ b/lib/omniauth/version.rb
@@ -1,3 +1,3 @@
 module OmniAuth
-  VERSION = '1.4.3'.freeze
+  VERSION = '1.5.0'.freeze
 end

--- a/omniauth.gemspec
+++ b/omniauth.gemspec
@@ -5,7 +5,7 @@ require 'omniauth/version'
 
 Gem::Specification.new do |spec|
   spec.add_dependency 'hashie', ['>= 1.2', '< 4']
-  spec.add_dependency 'rack', ['>= 1.0', '< 3']
+  spec.add_dependency 'rack', ['>= 1.6.2', '< 3']
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.add_development_dependency 'rake', '>= 10.5'
   spec.authors       = ['Michael Bleigh', 'Erik Michaels-Ober', 'Tom Milewski']

--- a/omniauth.gemspec
+++ b/omniauth.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'omniauth'
   spec.require_paths = %w(lib)
   spec.required_rubygems_version = '>= 1.3.5'
+  spec.required_ruby_version = '>= 2.1.9'
   spec.summary       = spec.description
   spec.version       = OmniAuth::VERSION
 end

--- a/omniauth.gemspec
+++ b/omniauth.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'omniauth/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'hashie', ['~> 3.5.0', '< 4']
+  spec.add_dependency 'hashie', ['>= 3.4.6', '< 3.6.0']
   spec.add_dependency 'rack', ['>= 1.6.2', '< 3']
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/omniauth.gemspec
+++ b/omniauth.gemspec
@@ -4,10 +4,10 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'omniauth/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'hashie', ['>= 1.2', '< 4']
+  spec.add_dependency 'hashie', ['~> 3.5.0', '< 4']
   spec.add_dependency 'rack', ['>= 1.6.2', '< 3']
-  spec.add_development_dependency 'bundler', '~> 1.0'
-  spec.add_development_dependency 'rake', '>= 10.5'
+  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'rake', '~> 12.0'
   spec.authors       = ['Michael Bleigh', 'Erik Michaels-Ober', 'Tom Milewski']
   spec.description   = 'A generalized Rack framework for multiple-provider authentication.'
   spec.email         = ['michael@intridea.com', 'sferik@gmail.com', 'tmilewski@gmail.com']

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,5 +1,11 @@
 if RUBY_VERSION >= '1.9'
   require 'simplecov'
+  require 'coveralls'
+
+  SimpleCov.formatters = [
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter
+  ]
 
   SimpleCov.start do
     add_filter '/spec/'

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -4,7 +4,7 @@ if RUBY_VERSION >= '1.9'
   SimpleCov.start do
     add_filter '/spec/'
     add_filter '/vendor/'
-    minimum_coverage(92.91)
+    minimum_coverage(92.5)
   end
 end
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,8 +1,5 @@
 if RUBY_VERSION >= '1.9'
   require 'simplecov'
-  require 'coveralls'
-
-  SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter, Coveralls::SimpleCov::Formatter]
 
   SimpleCov.start do
     add_filter '/spec/'

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -7,7 +7,7 @@ if RUBY_VERSION >= '1.9'
   SimpleCov.start do
     add_filter '/spec/'
     add_filter '/vendor/'
-    minimum_coverage(92.93)
+    minimum_coverage(92.91)
   end
 end
 

--- a/spec/omniauth/auth_hash_spec.rb
+++ b/spec/omniauth/auth_hash_spec.rb
@@ -8,6 +8,11 @@ describe OmniAuth::AuthHash do
     expect(subject.info.first_name).to eq('Awesome')
   end
 
+  it 'does not try to parse `string` as InfoHash' do
+    subject.weird_field = {:info => 'string'}
+    expect(subject.weird_field.info).to eq 'string'
+  end
+
   describe '#valid?' do
     subject { OmniAuth::AuthHash.new(:uid => '123', :provider => 'example', :info => {:name => 'Steven'}) }
 

--- a/spec/omniauth/auth_hash_spec.rb
+++ b/spec/omniauth/auth_hash_spec.rb
@@ -105,5 +105,25 @@ describe OmniAuth::AuthHash do
         expect(OmniAuth::AuthHash::InfoHash.new(:name => 'Awesome')).to be_valid
       end
     end
+
+    require 'hashie/version'
+    if Gem::Version.new(Hashie::VERSION) >= Gem::Version.new('3.5.1')
+      context 'with Hashie 3.5.1+' do
+        around(:each) do |example|
+          original_logger = Hashie.logger
+          example.run
+          Hashie.logger = original_logger
+        end
+
+        it 'does not log anything in Hashie 3.5.1+' do
+          logger = double('Logger')
+          expect(logger).not_to receive(:warn)
+
+          Hashie.logger = logger
+
+          subject.name = 'test'
+        end
+      end
+    end
   end
 end

--- a/spec/omniauth/key_store_spec.rb
+++ b/spec/omniauth/key_store_spec.rb
@@ -1,0 +1,79 @@
+require 'helper'
+
+RSpec.describe OmniAuth::KeyStore do
+  let(:logger) { double('Logger') }
+
+  around(:each) do |example|
+    patched = monkey_patch_logger
+    example.run
+    remove_logger(patched)
+  end
+
+  context 'on Hashie < 3.5.0' do
+    let(:version) { '3.4.0' }
+
+    it 'does not log anything to the console' do
+      stub_const('Hashie::VERSION', version)
+      OmniAuth::KeyStore.override_logging
+      expect(logger).not_to receive(:info)
+      OmniAuth::KeyStore.new(:id => 1234)
+    end
+  end
+
+  context 'on Hashie 3.5.0 and 3.5.1' do
+    let(:version) { '3.5.0' }
+
+    it 'does not log anything to the console' do
+      stub_const('Hashie::VERSION', version)
+      OmniAuth::KeyStore.override_logging
+      expect(logger).not_to receive(:info)
+      OmniAuth::KeyStore.new(:id => 1234)
+    end
+  end
+
+  context 'on Hashie 3.5.2+' do
+    let(:version) { '3.5.2' }
+
+    around(:each) do |example|
+      patching = monkey_patch_unreleased_interface
+      example.run
+      remove_monkey_patch(patching)
+    end
+
+    it 'does not log anything to the console' do
+      stub_const('Hashie::VERSION', version)
+      OmniAuth::KeyStore.override_logging
+      expect(logger).not_to receive(:info)
+      OmniAuth::KeyStore.new(:id => 1234)
+    end
+  end
+
+  def monkey_patch_unreleased_interface
+    return false if OmniAuth::KeyStore.class.respond_to?(:disable_warnings, true)
+
+    OmniAuth::KeyStore.define_singleton_method(:disable_warnings) {}
+    OmniAuth::KeyStore.define_singleton_method(:log_built_in_message) { |*| }
+
+    true
+  end
+
+  def monkey_patch_logger
+    return unless Hashie.respond_to?(:logger)
+
+    original_logger = Hashie.logger
+    Hashie.logger = logger
+    original_logger
+  end
+
+  def remove_logger(logger)
+    return unless logger
+
+    Hashie.logger = logger
+  end
+
+  def remove_monkey_patch(perform)
+    return unless perform
+
+    OmniAuth::KeyStore.singleton_class.__send__(:remove_method, :disable_warnings)
+  end
+end

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -597,6 +597,11 @@ describe OmniAuth::Strategy do
         expect(response[1]['Location']).to eq('/auth/test/callback')
       end
 
+      it "doesn't short circuit the request if request method is not allowed" do
+        response = strategy.call(make_env('/auth/test', 'REQUEST_METHOD' => 'DELETE'))
+        expect(response[0]).to eq(404)
+      end
+
       it 'is case insensitive on request path' do
         expect(strategy.call(make_env('/AUTH/Test'))[0]).to eq(302)
       end

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -708,13 +708,6 @@ describe OmniAuth::Strategy do
         expect(strategy.env['rack.session']['omniauth.params']).to eq({})
       end
 
-      it 'sets omniauth.headers on the request phase' do
-        OmniAuth.config.mock_auth[:test] = {}
-
-        strategy.call(make_env('/auth/test', 'HTTP_FOO' => 'bar'))
-        expect(strategy.env['rack.session']['omniauth.headers']).to eq('FOO' => 'bar')
-      end
-
       it 'executes request hook on the request phase' do
         OmniAuth.config.mock_auth[:test] = {}
         OmniAuth.config.before_request_phase do |env|

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -703,6 +703,13 @@ describe OmniAuth::Strategy do
         expect(strategy.env['rack.session']['omniauth.params']).to eq({})
       end
 
+      it 'sets omniauth.headers on the request phase' do
+        OmniAuth.config.mock_auth[:test] = {}
+
+        strategy.call(make_env('/auth/test', 'HTTP_FOO' => 'bar'))
+        expect(strategy.env['rack.session']['omniauth.headers']).to eq('FOO' => 'bar')
+      end
+
       it 'executes request hook on the request phase' do
         OmniAuth.config.mock_auth[:test] = {}
         OmniAuth.config.before_request_phase do |env|

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -685,11 +685,22 @@ describe OmniAuth::Strategy do
         expect(strategy.env['foobar']).to eq('baz')
       end
 
-      it 'sets omniauth.params on the request phase' do
+      it 'sets omniauth.params with query params on the request phase' do
         OmniAuth.config.mock_auth[:test] = {}
 
         strategy.call(make_env('/auth/test', 'QUERY_STRING' => 'foo=bar'))
         expect(strategy.env['rack.session']['omniauth.params']).to eq('foo' => 'bar')
+      end
+
+      it 'does not set body parameters of POST request on the request phase' do
+        OmniAuth.config.mock_auth[:test] = {}
+
+        props = {
+          'REQUEST_METHOD' => 'POST',
+          'rack.input' => StringIO.new('foo=bar')
+        }
+        strategy.call(make_env('/auth/test', props))
+        expect(strategy.env['rack.session']['omniauth.params']).to eq({})
       end
 
       it 'executes request hook on the request phase' do

--- a/spec/omniauth_spec.rb
+++ b/spec/omniauth_spec.rb
@@ -91,7 +91,7 @@ describe OmniAuth do
     describe 'mock auth' do
       before do
         @auth_hash = {:uid => '12345', :info => {:name => 'Joe', :email => 'joe@example.com'}}
-        @original_auth_hash = Marshal.load(Marshal.dump(@auth_hash))
+        @original_auth_hash = @auth_hash.dup
 
         OmniAuth.config.add_mock(:facebook, @auth_hash)
       end


### PR DESCRIPTION
I've got a strange error when updated to rails 4.2.6:
TypeError (wrong argument type Fixnum (expected Proc)) in compile_stack method
When i looked deeper i found out that this method test all the ancestors of the OmniAuth::Strategies::XXX (currently using one, e.g. Facebook). Among them there is sure an Object class which had an ancestor of its own a Process class in production environment. So the Process has a uid method which returns the Fixnum class and caused this error.
