### PR TITLE
Avoid ruby warnings

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -88,9 +88,12 @@ module OmniAuth
       end
 
       %w(uid info extra credentials).each do |fetcher|
-        class_eval <<-RUBY
+        class_eval <<-RUBY, __FILE__, __LINE__ + 1
+          attr_reader :#{fetcher}_proc
+          private :#{fetcher}_proc
+
           def #{fetcher}(&block)
-            return @#{fetcher}_proc unless block_given?
+            return #{fetcher}_proc unless block_given?
             @#{fetcher}_proc = block
           end
 


### PR DESCRIPTION
Some strategies use minitest, and it has enabled warnings by default. So there are long list  of warnings like this: https://travis-ci.org/mkdynamic/omniauth-facebook/jobs/139413665
