### PR TITLE
security issue in returning post parameters from session in callback phase

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -198,7 +198,7 @@ module OmniAuth
       setup_phase
       log :info, 'Request phase initiated.'
       # store query params from the request url, extracted in the callback_phase
-      session['omniauth.params'] = request.params
+      session['omniauth.params'] = request.GET
       OmniAuth.config.before_request_phase.call(env) if OmniAuth.config.before_request_phase
       if options.form.respond_to?(:call)
         log :info, 'Rendering form from supplied Rack endpoint.'
@@ -265,7 +265,7 @@ module OmniAuth
     def mock_request_call
       setup_phase
 
-      session['omniauth.params'] = request.params
+      session['omniauth.params'] = request.GET
       OmniAuth.config.before_request_phase.call(env) if OmniAuth.config.before_request_phase
       if request.params['origin']
         @env['rack.session']['omniauth.origin'] = request.params['origin']

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -685,11 +685,22 @@ describe OmniAuth::Strategy do
         expect(strategy.env['foobar']).to eq('baz')
       end
 
-      it 'sets omniauth.params on the request phase' do
+      it 'sets omniauth.params with query params on the request phase' do
         OmniAuth.config.mock_auth[:test] = {}
 
         strategy.call(make_env('/auth/test', 'QUERY_STRING' => 'foo=bar'))
         expect(strategy.env['rack.session']['omniauth.params']).to eq('foo' => 'bar')
+      end
+
+      it 'does not set body parameters of POST request on the request phase' do
+        OmniAuth.config.mock_auth[:test] = {}
+
+        props = {
+          'REQUEST_METHOD' => 'POST',
+          'rack.input' => StringIO.new('foo=bar')
+        }
+        strategy.call(make_env('/auth/test', props))
+        expect(strategy.env['rack.session']['omniauth.params']).to eq({})
       end
 
       it 'executes request hook on the request phase' do


### PR DESCRIPTION
Request phase of omniauth store `request.params` in session which are later assigned in env of callback phase. According do docs we should only store query params but in this case both GET and POST params get stored. POST params can contain `authenticity_token` of application to protect form CSRF issues. We shouldn't leak such tokens from POST params.

@sferik @jamesarosen @md5 