### PR TITLE
docs: TestCase expects class in strategy method array

### DIFF
--- a/lib/omniauth/test/strategy_test_case.rb
+++ b/lib/omniauth/test/strategy_test_case.rb
@@ -10,7 +10,7 @@ module OmniAuth
     #     include OmniAuth::Test::StrategyTestCase
     #     def strategy
     #       # return the parameters to a Rack::Builder map call:
-    #       [MyStrategy.new, :some, :configuration, :options => 'here']
+    #       [MyStrategy, :some, :configuration, :options => 'here']
     #     end
     #     setup do
     #       post '/auth/my_strategy/callback', :user => { 'name' => 'Dylan', 'id' => '445' }


### PR DESCRIPTION
The documentation included MyStrategy.new which would return an instance unless it fails due to lack of args.