### PR TITLE
reference hashie top level

### DIFF
--- a/lib/omniauth/auth_hash.rb
+++ b/lib/omniauth/auth_hash.rb
@@ -1,4 +1,4 @@
-require 'hashie/mash'
+require 'hashie'
 
 module OmniAuth
   # The AuthHash is a normalized schema returned by all OmniAuth

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -1,4 +1,4 @@
-require 'hashie/mash'
+require 'hashie'
 
 module OmniAuth
   class NoSessionError < StandardError; end


### PR DESCRIPTION
The latest version of hashie has broken our omniauth implementation.

```
Bundler::GemRequireError: There was an error while trying to load the gem 'omniauth-google-oauth2'.
Gem Load Error is: uninitialized constant Hashie::Extensions::RubyVersionCheck::ClassMethods::RubyVersion
Backtrace for gem load error is:

hashie-3.5.0/lib/hashie/extensions/ruby_version_check.rb:10:in `with_minimum_ruby'
hashie-3.5.0/lib/hashie/array.rb:8:in `<class:Array>'
hashie-3.5.0/lib/hashie/array.rb:5:in `<module:Hashie>'
hashie-3.5.0/lib/hashie/array.rb:4:in `<top (required)>'
hashie-3.5.0/lib/hashie/mash.rb:2:in `<top (required)>'
omniauth-1.3.2/lib/omniauth/strategy.rb:1:in `<top (required)>'
omniauth-1.3.2/lib/omniauth.rb:45:in `new'
omniauth-1.3.2/lib/omniauth.rb:45:in `defaults'
omniauth-1.3.2/lib/omniauth.rb:50:in `initialize'
lib/ruby/2.3.0/singleton.rb:142:in `new'
lib/ruby/2.3.0/singleton.rb:142:in `block in instance'
lib/ruby/2.3.0/singleton.rb:140:in `synchronize'
lib/ruby/2.3.0/singleton.rb:140:in `instance'
omniauth-1.3.2/lib/omniauth.rb:119:in `config'
omniauth-oauth2-1.3.1/lib/omniauth/strategies/oauth2.rb:131:in `<top (required)>'
omniauth-google-oauth2-0.2.10/lib/omniauth/strategies/google_oauth2.rb:3:in `<top (required)>'
omniauth-google-oauth2-0.2.10/lib/omniauth/google_oauth2.rb:1:in `<top (required)>'
omniauth-google-oauth2-0.2.10/lib/omniauth-google-oauth2.rb:1:in `<top (required)>'
```

I'm trying to fix it over in https://github.com/intridea/hashie/issues/391
It had a similar issue https://github.com/intridea/hashie/issues/367

But this also begs to ask, would it make sense to just `require "hashie"`?
Not sure about the memory implications