### PR TITLE
Dependency security updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'mime-types', '~> 1.25', :platforms => [:jruby_18]
   gem 'rack', '>= 1.6.2', :platforms => [:jruby_18, :jruby_19, :ruby_19, :ruby_20, :ruby_21]
   gem 'rack-test'
-  gem 'rest-client', '~> 1.6.0', :platforms => [:jruby_18]
+  gem 'rest-client', '~> 1.8.0', :platforms => [:jruby_18]
   gem 'rspec', '~> 3.0'
   gem 'rubocop', '>= 0.25', :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
   gem 'simplecov', '>= 0.9'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'jruby-openssl', :platforms => :jruby
+gem 'jruby-openssl', '>= 0.6', :platforms => :jruby
 gem 'rake', '~> 10.5'
 gem 'yard'
 

--- a/omniauth.gemspec
+++ b/omniauth.gemspec
@@ -5,7 +5,7 @@ require 'omniauth/version'
 
 Gem::Specification.new do |spec|
   spec.add_dependency 'hashie', ['>= 1.2', '< 4']
-  spec.add_dependency 'rack', ['>= 1.0', '< 3']
+  spec.add_dependency 'rack', ['>= 1.6.2', '< 3']
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.add_development_dependency 'rake', '>= 10.5'
   spec.authors       = ['Michael Bleigh', 'Erik Michaels-Ober', 'Tom Milewski']


### PR DESCRIPTION
Update `jruby-openssl`, `rest-client`, and `rack` dependency requirements to avoid potential dependency-related security issues.