### PR TITLE
Deal with relative url root installations

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -421,7 +421,12 @@ module OmniAuth
     end
 
     def request_path
-      @request_path ||= options[:request_path].is_a?(String) ? options[:request_path] : "#{path_prefix}/#{name}"
+      @request_path ||=
+        if options[:request_path].is_a?(String)
+          options[:request_path]
+        else
+          "#{script_name}#{path_prefix}/#{name}"
+        end
     end
 
     def callback_path
@@ -429,7 +434,7 @@ module OmniAuth
         path = options[:callback_path] if options[:callback_path].is_a?(String)
         path ||= current_path if options[:callback_path].respond_to?(:call) && options[:callback_path].call(env)
         path ||= custom_path(:request_path)
-        path ||= "#{path_prefix}/#{name}/callback"
+        path ||= "#{script_name}#{path_prefix}/#{name}/callback"
         path
       end
     end
@@ -441,7 +446,7 @@ module OmniAuth
     CURRENT_PATH_REGEX = %r{/$}.freeze
     EMPTY_STRING       = ''.freeze
     def current_path
-      @current_path ||= request.path_info.downcase.sub(CURRENT_PATH_REGEX, EMPTY_STRING)
+      @current_path ||= request.path.downcase.sub(CURRENT_PATH_REGEX, EMPTY_STRING)
     end
 
     def query_string
@@ -473,7 +478,7 @@ module OmniAuth
     end
 
     def callback_url
-      full_host + script_name + callback_path + query_string
+      full_host + callback_path + query_string
     end
 
     def script_name

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -588,6 +588,43 @@ describe OmniAuth::Strategy do
       end
     end
 
+    context 'with relative url root' do
+      let(:props) { { 'SCRIPT_NAME' => '/myapp' } }
+      it 'accepts the request' do
+        expect { strategy.call(make_env('/auth/test', props)) }.to raise_error('Request Phase')
+        expect(strategy.request_path).to eq('/myapp/auth/test')
+      end
+
+      it 'accepts the callback' do
+        expect { strategy.call(make_env('/auth/test/callback', props)) }.to raise_error('Callback Phase')
+      end
+
+      context 'callback_url' do
+        it 'redirects to the correctly prefixed callback' do
+          expect(strategy).to receive(:full_host).and_return('http://example.com')
+
+          expect { strategy.call(make_env('/auth/test', props)) }.to raise_error('Request Phase')
+
+          expect(strategy.callback_url).to eq('http://example.com/myapp/auth/test/callback')
+        end
+      end
+
+      context 'custom request' do
+        before do
+          @options = {:request_path => '/myapp/override', :callback_path => '/myapp/override/callback'}
+        end
+        it 'does not prefix a custom request path' do
+          expect(strategy).to receive(:full_host).and_return('http://example.com')
+
+          expect(strategy.request_path).to eq('/myapp/override')
+          expect { strategy.call(make_env('/override', props)) }.to raise_error('Request Phase')
+
+          expect(strategy.callback_url).to eq('http://example.com/myapp/override/callback')
+        end
+      end
+    end
+
+
     context 'request method restriction' do
       before(:context) do
         OmniAuth.config.allowed_request_methods = %i[put post]

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -589,21 +589,26 @@ describe OmniAuth::Strategy do
     end
 
     context 'with relative url root' do
-      let(:props) { { 'SCRIPT_NAME' => '/myapp' } }
+      let(:props) { {'SCRIPT_NAME' => '/myapp'} }
       it 'accepts the request' do
-        expect { strategy.call(make_env('/auth/test', props)) }.to raise_error('Request Phase')
+        expect(strategy).to receive(:fail!).with('Request Phase', kind_of(StandardError))
+
+        strategy.call(make_env('/auth/test', props))
         expect(strategy.request_path).to eq('/myapp/auth/test')
       end
 
       it 'accepts the callback' do
-        expect { strategy.call(make_env('/auth/test/callback', props)) }.to raise_error('Callback Phase')
+        expect(strategy).to receive(:fail!).with('Callback Phase', kind_of(StandardError))
+
+        strategy.call(make_env('/auth/test/callback', props))
       end
 
       context 'callback_url' do
         it 'redirects to the correctly prefixed callback' do
           expect(strategy).to receive(:full_host).and_return('http://example.com')
+          expect(strategy).to receive(:fail!).with('Request Phase', kind_of(StandardError))
 
-          expect { strategy.call(make_env('/auth/test', props)) }.to raise_error('Request Phase')
+          strategy.call(make_env('/auth/test', props))
 
           expect(strategy.callback_url).to eq('http://example.com/myapp/auth/test/callback')
         end
@@ -615,9 +620,11 @@ describe OmniAuth::Strategy do
         end
         it 'does not prefix a custom request path' do
           expect(strategy).to receive(:full_host).and_return('http://example.com')
+          expect(strategy).to receive(:fail!).with('Request Phase', kind_of(StandardError))
 
           expect(strategy.request_path).to eq('/myapp/override')
-          expect { strategy.call(make_env('/override', props)) }.to raise_error('Request Phase')
+
+          strategy.call(make_env('/override', props))
 
           expect(strategy.callback_url).to eq('http://example.com/myapp/override/callback')
         end


### PR DESCRIPTION
This PR allows OmniAuth to transparently handle relative url root installations by correctly prefixing the default `Strategy#request_path` and `Strategy#callback_path` with `SCRIPT_NAME` as provided by Rack.

Also, in order to detect the full current path, uses `Rack::Request#path` instead of `#path_info`, as the latter does not include SCRIPT_NAME.

A deeper question remains: What should happen with custom callback and request paths? I can't think of a case where a user with a relative url root installation would _not_ want to prefix its paths, regardless of setting a custom path or not.

However, since some people may have configured custom paths in order to deal with relative root, including this change may be breaking.

I have thus included a specific spec that asserts that custom request paths are _not_ prefixed.

This deals with: 

https://github.com/intridea/omniauth/issues/767
https://github.com/intridea/omniauth/issues/753

We've stumbled over these bugs while fixing our own OmniAuth relative url root path helpers over at https://github.com/opf/openproject/pull/4169


This is https://github.com/omniauth/omniauth/pull/837 updated to current master.