### PR TITLE
Loosen rack version requirement in gemspec

### DIFF
--- a/omniauth.gemspec
+++ b/omniauth.gemspec
@@ -5,7 +5,7 @@ require 'omniauth/version'
 
 Gem::Specification.new do |spec|
   spec.add_dependency 'hashie', ['>= 3.4.6', '< 3.6.0']
-  spec.add_dependency 'rack', ['>= 1.6.2', '< 3']
+  spec.add_dependency 'rack', ['>= 1.4.0', '< 3']
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.authors       = ['Michael Bleigh', 'Erik Michaels-Ober', 'Tom Milewski']


### PR DESCRIPTION
It seems this was originally bumped here 6f4c4253feb533070f1a2b3ac2bf8206b8178022

This is well-intentioned however it makes it impossible to use the gem with Rails 3.2 due to version conflict. Ensuring gems are up to date with fixes is the responsibility of the project maintainer, not the gems.

Setting it to 1.4.0 as a compromise (was 1.0.0 before the bump).

```
    rails (= 3.2.22.5) was resolved to 3.2.22.5, which depends on
      actionpack (= 3.2.22.5) was resolved to 3.2.22.5, which depends on
        rack (~> 1.4.5)
```