### PR TITLE
Add support for using developer strategy behind mapping

### DIFF
--- a/lib/omniauth/strategies/developer.rb
+++ b/lib/omniauth/strategies/developer.rb
@@ -35,12 +35,16 @@ module OmniAuth
       option :uid_field, :email
 
       def request_phase
-        form = OmniAuth::Form.new(:title => 'User Info', :url => callback_path)
+        form = OmniAuth::Form.new(:title => 'User Info', :url => callback_url)
         options.fields.each do |field|
           form.text_field field.to_s.capitalize.tr('_', ' '), field.to_s
         end
         form.button 'Sign In'
         form.to_response
+      end
+
+      def callback_url
+        script_name + callback_path
       end
 
       uid do

--- a/spec/omniauth/strategies/developer_spec.rb
+++ b/spec/omniauth/strategies/developer_spec.rb
@@ -69,5 +69,24 @@ describe OmniAuth::Strategies::Developer do
         expect(auth_hash.uid).to eq('User')
       end
     end
+
+    context 'behind mapping' do
+      let(:app) do
+        Rack::Builder.new do |b|
+          b.map '/api' do
+            b.use Rack::Session::Cookie, :secret => 'abc123'
+            b.use OmniAuth::Strategies::Developer
+            b.run lambda { |_env| [200, {}, ['Not Found']] }
+          end
+          b.run lambda { |_env| [200, {}, ['Not Found']] }
+        end.to_app
+      end
+
+      before(:each) { get '/auth/developer' }
+
+      it 'updates the action url to reflect it\'s relative position behind the mapping' do
+        expect(last_response.body).to be_include("action='/auth/developer/callback'")
+      end
+    end
   end
 end


### PR DESCRIPTION
If the Developer strategy is used behind middleware like this:

```
map '/api'
  use OmniAuth::Strategies::Developer

  # callback here for /auth/developer/callback
end
```

the callback path that is used in the form does not contain the
ENV['SCRIPT_NAME'] before the callback_path

Currently the form path would be:
/auth/developer/callback

But since our callback handler is also behind this mapping it
should be:
/api/auth/developer/callback

This fix prepends `script_name` to the `callback_path` to give us
the problem form submission url regardless of whether it's behind
a mapping or not