### PR TITLE
Allow for renaming/disabling of `origin` param

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,14 +14,14 @@ end
 group :test do
   gem 'coveralls', :require => false
   gem 'hashie', '>= 3.4.6', '< 3.6.0', :platforms => [:jruby_18]
-  gem 'json', '~> 2.0.3', :platforms => [:jruby_18, :jruby_19, :ruby_19]
+  gem 'json', '~> 2.0.3', :platforms => %i[jruby_18 jruby_19 ruby_19]
   gem 'mime-types', '~> 3.1', :platforms => [:jruby_18]
-  gem 'rack', '>= 1.6.2', :platforms => [:jruby_18, :jruby_19, :ruby_19, :ruby_20, :ruby_21]
+  gem 'rack', '>= 1.6.2', :platforms => %i[jruby_18 jruby_19 ruby_19 ruby_20 ruby_21]
   gem 'rack-test'
   gem 'rest-client', '~> 2.0.0', :platforms => [:jruby_18]
   gem 'rspec', '~> 3.5.0'
-  gem 'rubocop', '>= 0.47', :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
-  gem 'tins', '~> 1.13.0', :platforms => [:jruby_18, :jruby_19, :ruby_19]
+  gem 'rubocop', '>= 0.47', :platforms => %i[ruby_20 ruby_21 ruby_22 ruby_23 ruby_24]
+  gem 'tins', '~> 1.13.0', :platforms => %i[jruby_18 jruby_19 ruby_19]
 end
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -122,24 +122,50 @@ environment information on the callback request. It is entirely up to
 you how you want to implement the particulars of your application's
 authentication flow.
 
+## Configuring The `origin` Param
+The `origin` url parameter is typically used to inform where a user came from and where, should you choose to use it, they'd want to return to.
+
+There are three possible options:
+
+Default Flow:
+```ruby
+# /auth/twitter/?origin=[URL]
+# No change
+# If blank, `omniauth.origin` is set to HTTP_REFERER
+```
+
+Renaming Origin Param:
+```ruby
+# /auth/twitter/?return_to=[URL]
+# If blank, `omniauth.origin` is set to HTTP_REFERER
+provider :twitter, ENV['KEY'], ENV['SECRET'], origin_param: 'return_to'
+```
+
+Disabling Origin Param:
+```ruby
+# /auth/twitter
+# Origin handled externally, if need be. `omniauth.origin` is not set
+provider :twitter, ENV['KEY'], ENV['SECRET'], origin_param: false
+```
+
 ## Integrating OmniAuth Into Your Rails API
 The following middleware are (by default) included for session management in
-Rails applications. When using OmniAuth with a Rails API, you'll need to add 
+Rails applications. When using OmniAuth with a Rails API, you'll need to add
 one of these required middleware back in:
 
 - `ActionDispatch::Session::CacheStore`
 - `ActionDispatch::Session::CookieStore`
 - `ActionDispatch::Session::MemCacheStore`
 
-The trick to adding these back in is that, by default, they are passed 
-`session_options` when added (including the session key), so you can't just add 
-a `session_store.rb` initializer, add `use ActionDispatch::Session::CookieStore` 
+The trick to adding these back in is that, by default, they are passed
+`session_options` when added (including the session key), so you can't just add
+a `session_store.rb` initializer, add `use ActionDispatch::Session::CookieStore`
 and have sessions functioning as normal.
 
-To be clear: sessions may work, but your session options will be ignored 
-(i.e the session key will default to `_session_id`).  Instead of the 
+To be clear: sessions may work, but your session options will be ignored
+(i.e the session key will default to `_session_id`).  Instead of the
 initializer, you'll have to set the relevant options somewhere
-before your middleware is built (like `application.rb`) and pass them to your 
+before your middleware is built (like `application.rb`) and pass them to your
 preferred middleware, like this:
 
 **application.rb:**

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ rescue LoadError
   end
 end
 
-task :default => [:spec, :rubocop]
+task :default => %i[spec rubocop]
 
 namespace :perf do
   task :setup do

--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -41,7 +41,7 @@ module OmniAuth
         :form_css => Form::DEFAULT_CSS,
         :test_mode => false,
         :logger => default_logger,
-        :allowed_request_methods => [:get, :post],
+        :allowed_request_methods => %i[get post],
         :mock_auth => {:default => AuthHash.new('provider' => 'default', 'uid' => '1234', 'info' => {'name' => 'Example User'})}
       }
     end
@@ -141,7 +141,7 @@ module OmniAuth
     def deep_merge(hash, other_hash)
       target = hash.dup
 
-      other_hash.keys.each do |key|
+      other_hash.each_key do |key|
         if other_hash[key].is_a?(::Hash) && hash[key].is_a?(::Hash)
           target[key] = deep_merge(target[key], other_hash[key])
           next

--- a/lib/omniauth/strategies/developer.rb
+++ b/lib/omniauth/strategies/developer.rb
@@ -31,7 +31,7 @@ module OmniAuth
     class Developer
       include OmniAuth::Strategy
 
-      option :fields, [:name, :email]
+      option :fields, %i[name email]
       option :uid_field, :email
 
       def request_phase

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -88,7 +88,7 @@ module OmniAuth
         (instance_variable_defined?(:@args) && @args) || existing
       end
 
-      %w(uid info extra credentials).each do |fetcher|
+      %w[uid info extra credentials].each do |fetcher|
         class_eval <<-RUBY, __FILE__, __LINE__ + 1
           attr_reader :#{fetcher}_proc
           private :#{fetcher}_proc

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -14,6 +14,7 @@ module OmniAuth
       base.class_eval do
         option :setup, false
         option :skip_info, false
+        option :origin_param, 'origin'
       end
     end
 
@@ -200,21 +201,26 @@ module OmniAuth
     def request_call # rubocop:disable CyclomaticComplexity, MethodLength, PerceivedComplexity
       setup_phase
       log :info, 'Request phase initiated.'
+
       # store query params from the request url, extracted in the callback_phase
       session['omniauth.params'] = request.GET
       OmniAuth.config.before_request_phase.call(env) if OmniAuth.config.before_request_phase
+
       if options.form.respond_to?(:call)
         log :info, 'Rendering form from supplied Rack endpoint.'
         options.form.call(env)
       elsif options.form
         log :info, 'Rendering form from underlying application.'
         call_app!
+      elsif !options.origin_param
+        request_phase
       else
-        if request.params['origin']
-          env['rack.session']['omniauth.origin'] = request.params['origin']
+        if request.params[options.origin_param]
+          env['rack.session']['omniauth.origin'] = request.params[options.origin_param]
         elsif env['HTTP_REFERER'] && !env['HTTP_REFERER'].match(/#{request_path}$/)
           env['rack.session']['omniauth.origin'] = env['HTTP_REFERER']
         end
+
         request_phase
       end
     end

--- a/omniauth.gemspec
+++ b/omniauth.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'omniauth/version'
@@ -13,9 +14,9 @@ Gem::Specification.new do |spec|
   spec.email         = ['michael@intridea.com', 'sferik@gmail.com', 'tmilewski@gmail.com']
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.start_with?('spec/') }
   spec.homepage      = 'https://github.com/omniauth/omniauth'
-  spec.licenses      = %w(MIT)
+  spec.licenses      = %w[MIT]
   spec.name          = 'omniauth'
-  spec.require_paths = %w(lib)
+  spec.require_paths = %w[lib]
   spec.required_rubygems_version = '>= 1.3.5'
   spec.required_ruby_version = '>= 2.1.9'
   spec.summary       = spec.description

--- a/spec/omniauth/auth_hash_spec.rb
+++ b/spec/omniauth/auth_hash_spec.rb
@@ -64,13 +64,13 @@ describe OmniAuth::AuthHash do
 
     it 'displays the nickname if no name, first, or last is available' do
       subject.info.name = nil
-      %w(first_name last_name).each { |k| subject.info[k] = nil }
+      %w[first_name last_name].each { |k| subject.info[k] = nil }
       expect(subject.info.name).to eq('meatbag')
     end
 
     it 'displays the email if no name, first, last, or nick is available' do
       subject.info.name = nil
-      %w(first_name last_name nickname).each { |k| subject.info[k] = nil }
+      %w[first_name last_name nickname].each { |k| subject.info[k] = nil }
       expect(subject.info.name).to eq('fry@planetexpress.com')
     end
   end

--- a/spec/omniauth/strategies/developer_spec.rb
+++ b/spec/omniauth/strategies/developer_spec.rb
@@ -51,13 +51,13 @@ describe OmniAuth::Strategies::Developer do
       let(:app) do
         Rack::Builder.new do |b|
           b.use Rack::Session::Cookie, :secret => 'abc123'
-          b.use OmniAuth::Strategies::Developer, :fields => [:first_name, :last_name], :uid_field => :last_name
+          b.use OmniAuth::Strategies::Developer, :fields => %i[first_name last_name], :uid_field => :last_name
           b.run lambda { |_env| [200, {}, ['Not Found']] }
         end.to_app
       end
 
       before do
-        @options = {:uid_field => :last_name, :fields => [:first_name, :last_name]}
+        @options = {:uid_field => :last_name, :fields => %i[first_name last_name]}
         post '/auth/developer/callback', :first_name => 'Example', :last_name => 'User'
       end
 

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -224,6 +224,13 @@ describe OmniAuth::Strategy do
       expect(instance).to receive(:dup).and_return(instance)
       instance.call('rack.session' => {})
     end
+
+    it 'raises NoSessionError if rack.session isn\'t set' do
+      klass = Class.new
+      klass.send :include, OmniAuth::Strategy
+      instance = klass.new(app)
+      expect { instance.call({}) }.to raise_error(OmniAuth::NoSessionError)
+    end
   end
 
   describe '#inspect' do

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -106,18 +106,18 @@ describe OmniAuth::Strategy do
     end
 
     it 'sets args to the specified argument if there is one' do
-      subject.args [:abc, :def]
-      expect(subject.args).to eq([:abc, :def])
+      subject.args %i[abc def]
+      expect(subject.args).to eq(%i[abc def])
     end
 
     it 'is inheritable' do
-      subject.args [:abc, :def]
+      subject.args %i[abc def]
       c = Class.new(subject)
-      expect(c.args).to eq([:abc, :def])
+      expect(c.args).to eq(%i[abc def])
     end
 
     it 'accepts corresponding options as default arg values' do
-      subject.args [:a, :b]
+      subject.args %i[a b]
       subject.option :a, '1'
       subject.option :b, '2'
 
@@ -130,7 +130,7 @@ describe OmniAuth::Strategy do
 
   context 'fetcher procs' do
     subject { fresh_strategy }
-    %w(uid info credentials extra).each do |fetcher|
+    %w[uid info credentials extra].each do |fetcher|
       describe ".#{fetcher}" do
         it 'sets and retrieve a proc' do
           proc = lambda { 'Hello' }
@@ -143,7 +143,7 @@ describe OmniAuth::Strategy do
 
   context 'fetcher stacks' do
     subject { fresh_strategy }
-    %w(uid info credentials extra).each do |fetcher|
+    %w[uid info credentials extra].each do |fetcher|
       describe ".#{fetcher}_stack" do
         it 'is an array of called ancestral procs' do
           fetchy = proc { 'Hello' }
@@ -154,7 +154,7 @@ describe OmniAuth::Strategy do
     end
   end
 
-  %w(request_phase).each do |abstract_method|
+  %w[request_phase].each do |abstract_method|
     context abstract_method.to_s do
       it 'raises a NotImplementedError' do
         strat = Class.new
@@ -208,7 +208,7 @@ describe OmniAuth::Strategy do
       end
 
       it 'sets options based on the arguments if they are supplied' do
-        subject.args [:abc, :def]
+        subject.args %i[abc def]
         s = subject.new app, 123, 456
         expect(s.options[:abc]).to eq(123)
         expect(s.options[:def]).to eq(456)
@@ -277,7 +277,7 @@ describe OmniAuth::Strategy do
     end
   end
 
-  %w(info credentials extra).each do |fetcher|
+  %w[info credentials extra].each do |fetcher|
     subject { fresh_strategy }
     it "is the current class's proc call if one exists" do
       subject.send(fetcher) { {:abc => 123} }
@@ -302,7 +302,7 @@ describe OmniAuth::Strategy do
     context 'omniauth.origin' do
       context 'disabled' do
         it 'does not set omniauth.origin' do
-          @options = { :origin_param => false }
+          @options = {:origin_param => false}
           expect { strategy.call(make_env('/auth/test', 'QUERY_STRING' => 'return=/foo')) }.to raise_error('Request Phase')
           expect(strategy.last_env['rack.session']['omniauth.origin']).to eq(nil)
         end
@@ -310,7 +310,7 @@ describe OmniAuth::Strategy do
 
       context 'custom' do
         it 'sets from a custom param' do
-          @options = { :origin_param => 'return' }
+          @options = {:origin_param => 'return'}
           expect { strategy.call(make_env('/auth/test', 'QUERY_STRING' => 'return=/foo')) }.to raise_error('Request Phase')
           expect(strategy.last_env['rack.session']['omniauth.origin']).to eq('/foo')
         end
@@ -528,7 +528,7 @@ describe OmniAuth::Strategy do
       end
 
       after do
-        OmniAuth.config.allowed_request_methods = [:get, :post]
+        OmniAuth.config.allowed_request_methods = %i[get post]
       end
     end
 


### PR DESCRIPTION
This PR allows for renaming or disabling of the origin param per the issue (#910) that @97jaz submitted. [Backwards Compatible]

**Examples**

Default Flow:
```ruby
# https://www.domain.com/auth/twitter/?origin=[URL]
# No change
```
Renaming Origin Param:
```ruby
# https://www.domain.com/auth/twitter/?return_to=[URL]
provider :twitter, ENV['KEY'], ENV['SECRET'], origin_param: 'return_to'
```

Disabling Origin Param:
```ruby
# https://www.domain.com/auth/twitter
# Redirects handled externally, `omniauth.origin` is not set
provider :twitter, ENV['KEY'], ENV['SECRET'], origin_param: false
```