### PR TITLE
Adds config option to disable omniauth.params

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -15,6 +15,7 @@ module OmniAuth
         option :setup, false
         option :skip_info, false
         option :origin_param, 'origin'
+        option :store_params, true
       end
     end
 
@@ -203,7 +204,7 @@ module OmniAuth
       log :info, 'Request phase initiated.'
 
       # store query params from the request url, extracted in the callback_phase
-      session['omniauth.params'] = request.GET
+      session['omniauth.params'] = request.GET if options.store_params
       OmniAuth.config.before_request_phase.call(env) if OmniAuth.config.before_request_phase
 
       if options.form.respond_to?(:call)
@@ -271,10 +272,10 @@ module OmniAuth
       call_app!
     end
 
-    def mock_request_call
+    def mock_request_call # rubocop:disable CyclomaticComplexity, PerceivedComplexity
       setup_phase
 
-      session['omniauth.params'] = request.GET
+      session['omniauth.params'] = request.GET if options.store_params
       OmniAuth.config.before_request_phase.call(env) if OmniAuth.config.before_request_phase
       if options.origin_param
         if request.params[options.origin_param]


### PR DESCRIPTION
Similar to #912, this PR adds an option, `store_params`, which controls whether `omniauth.params` is preserved in the session. It defaults to `true` for backward compatibility.

Background: I had a test case in my application for the scenario described in #910, and it continued to fail after updating my version of the omniauth gem to 1.7.0 and 1.7.1. The test sends a very long string in the `origin` request parameter, and expects that it will not result in a cookie overflow exception -- but the exception was still being raised. And that's because OmniAuth was still trying to put the the very long query parameter in the session, this time under `omniauth.params`.