### PR TITLE
Update for frozen-string-literal friendliness.

### DIFF
--- a/lib/omniauth/form.rb
+++ b/lib/omniauth/form.rb
@@ -9,7 +9,7 @@ module OmniAuth
       options[:header_info] ||= ''
       self.options = options
 
-      @html = ''.dup
+      @html = +'' # unary + string allows it to be mutable if strings are frozen
       @with_custom_button = false
       @footer = nil
       header(options[:title], options[:header_info])

--- a/lib/omniauth/form.rb
+++ b/lib/omniauth/form.rb
@@ -9,7 +9,7 @@ module OmniAuth
       options[:header_info] ||= ''
       self.options = options
 
-      @html = ''
+      @html = ''.dup
       @with_custom_button = false
       @footer = nil
       header(options[:title], options[:header_info])


### PR DESCRIPTION
One minor change that keeps all tests green when frozen string literals are in play in MRI 2.4+.

I've done this testing by adding the pragma comment to all Ruby files in lib and spec locally, but have not included those changes in this PR. I'm happy to add them in if you'd like, I just don't want to presume whether that's preferred or not.