### PR TITLE
Allow for using latest version of hashie

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 
 group :test do
   gem 'coveralls', :require => false
-  gem 'hashie', '>= 3.4.6', '< 3.6.0', :platforms => [:jruby_18]
+  gem 'hashie', '>= 3.4.6', '< 3.7.0', :platforms => [:jruby_18]
   gem 'json', '~> 2.0.3', :platforms => %i[jruby_18 jruby_19 ruby_19]
   gem 'mime-types', '~> 3.1', :platforms => [:jruby_18]
   gem 'rack', '>= 1.6.2', :platforms => %i[jruby_18 jruby_19 ruby_19 ruby_20 ruby_21]

--- a/omniauth.gemspec
+++ b/omniauth.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'omniauth/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'hashie', ['>= 3.4.6', '< 3.6.0']
+  spec.add_dependency 'hashie', ['>= 3.4.6', '< 3.7.0']
   spec.add_dependency 'rack', ['>= 1.6.2', '< 3']
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 12.0'


### PR DESCRIPTION
A new version of Hashie is out but omniauth is locked to a maximum version of 3.6.0. This PR bumps the max allowable version to just under 3.7.0.