### PR TITLE
Update to rack 2.0.6 due to CVE-2018-16471

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'hashie', '>= 3.4.6', '< 3.7.0', :platforms => [:jruby_18]
   gem 'json', '~> 2.0.3', :platforms => %i[jruby_18 jruby_19 ruby_19]
   gem 'mime-types', '~> 3.1', :platforms => [:jruby_18]
-  gem 'rack', '>= 1.6.2', :platforms => %i[jruby_18 jruby_19 ruby_19 ruby_20 ruby_21]
+  gem 'rack', '>= 2.0.6', :platforms => %i[jruby_18 jruby_19 ruby_19 ruby_20 ruby_21]
   gem 'rack-test'
   gem 'rest-client', '~> 2.0.0', :platforms => [:jruby_18]
   gem 'rspec', '~> 3.5.0'


### PR DESCRIPTION
```
Name: rack
Version: 2.0.1
Advisory: CVE-2018-16471
Criticality: Unknown
URL: https://groups.google.com/forum/#!topic/ruby-security-ann/NAalCee8n6o
Title: Possible XSS vulnerability in Rack
Solution: upgrade to ~> 1.6.11, >= 2.0.6
```