### PR TITLE
Allow Proc object to be set to options[:path_prefix]

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -374,7 +374,9 @@ module OmniAuth
     end
 
     def path_prefix
-      options[:path_prefix] || OmniAuth.config.path_prefix
+      path = options[:path_prefix] if is_a?(String)
+      path ||= options[:path_prefix].call if options[:path_prefix].respond_to?(:call)
+      path ||= OmniAuth.config.path_prefix
     end
 
     def custom_path(kind)

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -489,34 +489,69 @@ describe OmniAuth::Strategy do
     end
 
     context 'custom prefix' do
-      before do
-        @options = {:path_prefix => '/wowzers'}
-      end
-
-      it 'uses a custom prefix for request' do
-        expect { strategy.call(make_env('/wowzers/test')) }.to raise_error('Request Phase')
-      end
-
-      it 'uses a custom prefix for callback' do
-        expect { strategy.call(make_env('/wowzers/test/callback')) }.to raise_error('Callback Phase')
-      end
-
-      context 'callback_url' do
-        it 'uses a custom prefix' do
-          expect(strategy).to receive(:full_host).and_return('http://example.com')
-
-          expect { strategy.call(make_env('/wowzers/test')) }.to raise_error('Request Phase')
-
-          expect(strategy.callback_url).to eq('http://example.com/wowzers/test/callback')
+      context 'path_prefix is a String' do
+        before do
+          @options = {:path_prefix => '/wowzers'}
         end
 
-        it 'preserves the query parameters' do
-          allow(strategy).to receive(:full_host).and_return('http://example.com')
-          begin
-            strategy.call(make_env('/auth/test', 'QUERY_STRING' => 'id=5'))
-          rescue RuntimeError
+        it 'uses a custom prefix for request' do
+          expect { strategy.call(make_env('/wowzers/test')) }.to raise_error('Request Phase')
+        end
+
+        it 'uses a custom prefix for callback' do
+          expect { strategy.call(make_env('/wowzers/test/callback')) }.to raise_error('Callback Phase')
+        end
+
+        context 'callback_url' do
+          it 'uses a custom prefix' do
+            expect(strategy).to receive(:full_host).and_return('http://example.com')
+
+            expect { strategy.call(make_env('/wowzers/test')) }.to raise_error('Request Phase')
+
+            expect(strategy.callback_url).to eq('http://example.com/wowzers/test/callback')
           end
-          expect(strategy.callback_url).to eq('http://example.com/wowzers/test/callback?id=5')
+
+          it 'preserves the query parameters' do
+            allow(strategy).to receive(:full_host).and_return('http://example.com')
+            begin
+              strategy.call(make_env('/auth/test', 'QUERY_STRING' => 'id=5'))
+            rescue RuntimeError
+            end
+            expect(strategy.callback_url).to eq('http://example.com/wowzers/test/callback?id=5')
+          end
+        end
+      end
+
+      context 'path_prefix is a Proc' do
+        before do
+          @options = {:path_prefix => -> { '/wowzers' } }
+        end
+
+        it 'uses a custom prefix for request' do
+          expect { strategy.call(make_env('/wowzers/test')) }.to raise_error('Request Phase')
+        end
+
+        it 'uses a custom prefix for callback' do
+          expect { strategy.call(make_env('/wowzers/test/callback')) }.to raise_error('Callback Phase')
+        end
+
+        context 'callback_url' do
+          it 'uses a custom prefix' do
+            expect(strategy).to receive(:full_host).and_return('http://example.com')
+
+            expect { strategy.call(make_env('/wowzers/test')) }.to raise_error('Request Phase')
+
+            expect(strategy.callback_url).to eq('http://example.com/wowzers/test/callback')
+          end
+
+          it 'preserves the query parameters' do
+            allow(strategy).to receive(:full_host).and_return('http://example.com')
+            begin
+              strategy.call(make_env('/auth/test', 'QUERY_STRING' => 'id=5'))
+            rescue RuntimeError
+            end
+            expect(strategy.callback_url).to eq('http://example.com/wowzers/test/callback?id=5')
+          end
         end
       end
     end


### PR DESCRIPTION
To use any other values, that are evaluated after omniauth `options` value, as a `options[:path_prefix]` value, it is better to evaluate `options[:path_prefix]` lazily.

For example, there is a possibility that developers want to use values defined in rails project's `config/initializers/**.rb` files, for omniauth's `options` value.

And, I added the case `options[:path_prefix]` value is Proc class instance to `#path_prefix` method and tested its case.