### PR TITLE
Update the example to match the defaults used by Rails. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ steps are necessary for your application. For example, in a Rails app I
 would add a line in my `routes.rb` file like this:
 
 ```ruby
-get '/auth/:provider/callback', to: 'sessions#create'
+post '/auth/:provider/callback', to: 'sessions#create'
 ```
 
 And I might then have a `SessionsController` with code that looks
@@ -96,6 +96,8 @@ something like this:
 
 ```ruby
 class SessionsController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: :create
+
   def create
     @user = User.find_or_create_from_auth_hash(auth_hash)
     self.current_user = @user


### PR DESCRIPTION
This prevents the "Can't verify CSRF token authenticity" error when using the gem for the first time with Rails.

The default `developer` strategy uses HTTP POST (https://github.com/omniauth/omniauth/blob/master/lib/omniauth/form.rb#L78) to submit the values and Rails by default attempts to validate these requests. 

The [FAQ in the Wiki](https://github.com/omniauth/omniauth/wiki/FAQ) suggests the changes that I am submitting in this pull request.