### PR TITLE
limit Builder#provider's symbol lookup to constants under OmniAuth::Strategies

### DIFF
--- a/lib/omniauth/builder.rb
+++ b/lib/omniauth/builder.rb
@@ -50,7 +50,7 @@ module OmniAuth
         middleware = klass
       else
         begin
-          middleware = OmniAuth::Strategies.const_get(OmniAuth::Utils.camelize(klass.to_s).to_s)
+          middleware = OmniAuth::Strategies.const_get(OmniAuth::Utils.camelize(klass.to_s).to_s, false)
         rescue NameError
           raise(LoadError.new("Could not find matching strategy for #{klass.inspect}. You may need to install an additional gem (such as omniauth-#{klass})."))
         end

--- a/spec/omniauth/builder_spec.rb
+++ b/spec/omniauth/builder_spec.rb
@@ -3,7 +3,7 @@ require 'helper'
 describe OmniAuth::Builder do
   describe '#provider' do
     it 'translates a symbol to a constant' do
-      expect(OmniAuth::Strategies).to receive(:const_get).with('MyStrategy').and_return(Class.new)
+      expect(OmniAuth::Strategies).to receive(:const_get).with('MyStrategy', false).and_return(Class.new)
       OmniAuth::Builder.new(nil) do
         provider :my_strategy
       end
@@ -25,6 +25,16 @@ describe OmniAuth::Builder do
           provider :lorax
         end
       end.to raise_error(LoadError, 'Could not find matching strategy for :lorax. You may need to install an additional gem (such as omniauth-lorax).')
+    end
+
+    it "doesn't translate a symbol to a top-level constant" do
+      class MyStrategy; end
+
+      expect do
+        OmniAuth::Builder.new(nil) do
+          provider :my_strategy
+        end
+      end.to raise_error(LoadError, 'Could not find matching strategy for :my_strategy. You may need to install an additional gem (such as omniauth-my_strategy).')
     end
   end
 


### PR DESCRIPTION
When giving `Builder#provider` the name of a provider as a symbol, the lookup can find a top-level constant by that name. I'm assuming the intention is that providers named by symbols are expected to be defined under `OmniAuth::Strategies`.

i.e. this raises no exception:

```ruby
module FancyService; end

Rails.application.config.middleware.use OmniAuth::Builder do
  provider :fancy_service
end
```

Though you don't get an exception immediately, you will get an exception during a request when the middleware actually executes (assuming that top-level constant is not in fact a well-formed strategy).

I ran across this in a Rails development environment, with constant autoloading.  My app defines both a top-level constant `::FancyService` (unrelated to auth) and a nested constant `OmniAuth::Strategies::FancyService`. At the time of execution of my `Builder#provider` call, `::FancyService` had already been loaded but `OmniAuth::Strategies::FancyService` had not yet been loaded, and the `provider :fancy_service` syntax was finding the top-level constant.  (Using the explicit `provider OmniAuth::Strategies::FancyService` syntax is of course a fine workaround, so this issue is not a blocker for me.)

The fix is to change the `const_get` in `Builder#provider` to use the optional second argument, "inherit" ([docs](https://ruby-doc.org/core-2.6.3/Module.html#method-i-const_get)). Setting it to `false` prevents the `const_get` from finding the top-level `::FancyService`.

To demonstrate the difference, add these two files into an empty Rails app (tested on Rails 4.2.9 and 5.2.3):

```ruby
# app/models/fancy_service.rb
module FancyService
end
```

```ruby
# app/models/omni_auth/strategies/fancy_service.rb
module OmniAuth
  module Strategies
    class FancyService
    end
  end
end
```

Here's how to reproduce that unexpected behavior at a rails console:

```
irb> ::FancyService # trigger autoload
FancyService
irb> ::OmniAuth::Strategies.const_get(:FancyService)
FancyService
```

Compared to what happens if you set `const_get`'s "inherit" to `false` (in a new console):

```
irb> ::FancyService # trigger autoload
FancyService
irb> ::OmniAuth::Strategies.const_get(:FancyService, false)
OmniAuth::Strategies::FancyService
```