### PR TITLE
Add optional rack-protection-based CSRF check.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :test do
   gem 'json', '~> 2.0.3', :platforms => %i[jruby_18 jruby_19 ruby_19]
   gem 'mime-types', '~> 3.1', :platforms => [:jruby_18]
   gem 'rack', '>= 2.0.6', :platforms => %i[jruby_18 jruby_19 ruby_19 ruby_20 ruby_21]
+  gem 'rack-protection', '>= 2'
   gem 'rack-test'
   gem 'rest-client', '~> 2.0.0', :platforms => [:jruby_18]
   gem 'rspec', '~> 3.5.0'

--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -15,6 +15,7 @@ module OmniAuth
   autoload :Form,     'omniauth/form'
   autoload :AuthHash, 'omniauth/auth_hash'
   autoload :FailureEndpoint, 'omniauth/failure_endpoint'
+  autoload :AuthenticityCheck, 'omniauth/authenticity_check'
 
   def self.strategies
     @strategies ||= []

--- a/lib/omniauth/authenticity_check.rb
+++ b/lib/omniauth/authenticity_check.rb
@@ -1,0 +1,23 @@
+require 'rack-protection'
+
+module OmniAuth
+  class AuthenticityCheck < Rack::Protection::AuthenticityToken
+    def initialize(options = {})
+      @options = default_options.merge(options)
+    end
+
+    def call(env)
+      return if accepts?(env)
+
+      instrument env
+      react env
+    end
+
+    def deny(env)
+      warn env, "attack prevented by #{self.class}"
+      raise OmniAuth::InvalidSessionError.new options[:message]
+    end
+
+    default_reaction :deny
+  end
+end

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -2,6 +2,7 @@ require 'omniauth/key_store'
 
 module OmniAuth
   class NoSessionError < StandardError; end
+  class InvalidSessionError < StandardError; end
   # The Strategy is the base unit of OmniAuth's ability to
   # wrangle multiple providers. Each strategy provided by
   # OmniAuth includes this mixin to gain the default functionality
@@ -190,6 +191,8 @@ module OmniAuth
       return other_phase if respond_to?(:other_phase)
 
       @app.call(env)
+    rescue OmniAuth::InvalidSessionError => e
+      [403, {'Content-Type' => 'text/plain'}, [e.message]]
     end
 
     # Responds to an OPTIONS request.


### PR DESCRIPTION
This is related to #809 and related discussions around CVE-2015-9284. `OmniAuth::AuthenticityCheck` is available to hook into `rack-protection` (provided that gem is available), and will reject requests that do not come with a CSRF token that matches what's stored in the session. This is useful _only_ in non-Rails applications (whereas otherwise people are better served using the `omniauth-rails_csrf_protection` gem).

To enable this approach, you will need to set up the `before_request_phase` hook:

```ruby
OmniAuth.config.before_request_phase = OmniAuth::AuthenticityCheck.new
```

… and then ensure your session's `csrf` token is passed through in each POST request to `/auth/:provider`, as per [the documentation](https://github.com/sinatra/sinatra/blob/master/rack-protection/lib/rack/protection/authenticity_token.rb) in `rack-protection`.