### PR TITLE
Fixing the build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 bundler_args: --without development
 before_install:
-  - gem update --system
-  - gem update bundler
+  - gem install bundler --version 1.17.3
 cache: bundler
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - JRUBY_OPTS="$JRUBY_OPTS --debug"
 language: ruby
 rvm:
-  - jruby-9000
+  - jruby-9.2.7.0
   - 2.2.10
   - 2.3.8
   - 2.4.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,11 @@ env:
 language: ruby
 rvm:
   - jruby-9000
-  - 2.2.9
-  - 2.3.5
-  - 2.4.4
-  - 2.5.3
+  - 2.2.10
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
   - jruby-head
   - ruby-head
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 bundler_args: --without development
 before_install:
   - gem install bundler --version 1.17.3
+install:
+  - bundle _1.17.3_ install --jobs=3 --retry=3
 cache: bundler
 env:
   global:

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :test do
   gem 'rack-test'
   gem 'rest-client', '~> 2.0.0', :platforms => [:jruby_18]
   gem 'rspec', '~> 3.5.0'
-  gem 'rubocop', '>= 0.58.2', :platforms => %i[ruby_20 ruby_21 ruby_22 ruby_23 ruby_24]
+  gem 'rubocop', '~> 0.58.2', :platforms => %i[ruby_20 ruby_21 ruby_22 ruby_23 ruby_24]
   gem 'tins', '~> 1.13.0', :platforms => %i[jruby_18 jruby_19 ruby_19]
 end
 

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -406,7 +406,7 @@ module OmniAuth
       options[:setup_path] || "#{path_prefix}/#{name}/setup"
     end
 
-    CURRENT_PATH_REGEX = %r{/$}.freeze
+    CURRENT_PATH_REGEX = %r{/$}
     EMPTY_STRING       = ''.freeze
     def current_path
       @current_path ||= request.path_info.downcase.sub(CURRENT_PATH_REGEX, EMPTY_STRING)


### PR DESCRIPTION
A bunch of small changes - which I can wrap up into a single commit or two if preferred. Each commit's message is hopefully reasonably clear, but a quick summary:

* Use the latest patch releases of Ruby versions. This also helped the code coverage stats be more consistent in JRuby.
* Ensure bundler v1 is used (which is more work that I'd like - due to RVM insisting on installing bundler v2 as a default gem for JRuby, and thus can't be uninstalled).
* Avoid upgrading ruby gems during the build - again, not ideal, but MRI 2.2 complains otherwise.
* Lock Rubocop to 0.58.

The goal here was to get the build green again, without any code changes (and the only code change that's been made is removing a `freeze` call on a regular expression, because Rubocop says it's already immutable). Rubocop itself is a very old version, but making the upgrade to a newer one will almost certainly introduce more code changes - and I think that _should_ happen at some point, but not in this PR.

There's also the challenge that the latest Rubocop releases don't support the discontinued MRI 2.2 - at what point should OmniAuth make the same jump as well?