### PR TITLE
Allow Hashie version 4.0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 bundler_args: --without development
 before_install:
   - gem update --system
-  - gem update bundler
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '~> 1.14'
 cache: bundler
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 bundler_args: --without development
 before_install:
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
-  - gem install bundler -v '~> 1.14'
+  - gem install bundler -v '1.17.3'
+install:
+ - bundle _1.17.3_ install --jobs=3 --retry=3
 cache: bundler
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 bundler_args: --without development
 before_install:
-  - gem update --system
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
   - gem install bundler -v '~> 1.14'
 cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :test do
   gem 'rack-test'
   gem 'rest-client', '~> 2.0.0', :platforms => [:jruby_18]
   gem 'rspec', '~> 3.5.0'
-  gem 'rubocop', '>= 0.58.2', '< 0.70.0', :platforms => %i[ruby_20 ruby_21 ruby_22 ruby_23 ruby_24]
+  gem 'rubocop', '>= 0.58.2', '< 0.69.0', :platforms => %i[ruby_20 ruby_21 ruby_22 ruby_23 ruby_24]
   gem 'tins', '~> 1.13.0', :platforms => %i[jruby_18 jruby_19 ruby_19]
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :test do
   gem 'rack-test'
   gem 'rest-client', '~> 2.0.0', :platforms => [:jruby_18]
   gem 'rspec', '~> 3.5.0'
-  gem 'rubocop', '>= 0.58.2', :platforms => %i[ruby_20 ruby_21 ruby_22 ruby_23 ruby_24]
+  gem 'rubocop', '>= 0.58.2', '< 0.70.0', :platforms => %i[ruby_20 ruby_21 ruby_22 ruby_23 ruby_24]
   gem 'tins', '~> 1.13.0', :platforms => %i[jruby_18 jruby_19 ruby_19]
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 
 group :test do
   gem 'coveralls', :require => false
-  gem 'hashie', '>= 3.4.6', '< 3.7.0', :platforms => [:jruby_18]
+  gem 'hashie', '>= 3.4.6', '~> 4.0.0', :platforms => [:jruby_18]
   gem 'json', '~> 2.0.3', :platforms => %i[jruby_18 jruby_19 ruby_19]
   gem 'mime-types', '~> 3.1', :platforms => [:jruby_18]
   gem 'rack', '>= 2.0.6', :platforms => %i[jruby_18 jruby_19 ruby_19 ruby_20 ruby_21]

--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -132,7 +132,7 @@ module OmniAuth
   end
 
   module Utils
-    module_function
+  module_function # rubocop:disable Layout/IndentationWidth
 
     def form_css
       "<style type='text/css'>#{OmniAuth.config.form_css}</style>"

--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -132,7 +132,7 @@ module OmniAuth
   end
 
   module Utils
-  module_function
+    module_function
 
     def form_css
       "<style type='text/css'>#{OmniAuth.config.form_css}</style>"

--- a/lib/omniauth/builder.rb
+++ b/lib/omniauth/builder.rb
@@ -1,16 +1,5 @@
 module OmniAuth
   class Builder < ::Rack::Builder
-    def initialize(app, &block)
-      @options = nil
-      if rack14? || rack2?
-        super
-      else
-        @app = app
-        super(&block)
-        @ins << @app
-      end
-    end
-
     def on_failure(&block)
       OmniAuth.config.on_failure = block
     end
@@ -32,7 +21,7 @@ module OmniAuth
     end
 
     def options(options = false)
-      return @options || {} if options == false
+      return @options ||= {} if options == false
 
       @options = options
     end
@@ -54,16 +43,6 @@ module OmniAuth
 
     def call(env)
       to_app.call(env)
-    end
-
-  private
-
-    def rack14?
-      Rack.release.start_with?('1.') && (Rack.release.split('.')[1].to_i >= 4)
-    end
-
-    def rack2?
-      Rack.release.start_with? '2.'
     end
   end
 end

--- a/lib/omniauth/builder.rb
+++ b/lib/omniauth/builder.rb
@@ -11,14 +11,6 @@ module OmniAuth
       end
     end
 
-    def rack14?
-      Rack.release.start_with?('1.') && (Rack.release.split('.')[1].to_i >= 4)
-    end
-
-    def rack2?
-      Rack.release.start_with? '2.'
-    end
-
     def on_failure(&block)
       OmniAuth.config.on_failure = block
     end
@@ -62,6 +54,16 @@ module OmniAuth
 
     def call(env)
       to_app.call(env)
+    end
+
+  private
+
+    def rack14?
+      Rack.release.start_with?('1.') && (Rack.release.split('.')[1].to_i >= 4)
+    end
+
+    def rack2?
+      Rack.release.start_with? '2.'
     end
   end
 end

--- a/omniauth.gemspec
+++ b/omniauth.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'omniauth/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'hashie', ['>= 3.4.6', '< 3.7.0']
+  spec.add_dependency 'hashie', ['>= 3.4.6', '~> 4.0.0']
   spec.add_dependency 'rack', ['>= 1.6.2', '< 3']
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/spec/omniauth/builder_spec.rb
+++ b/spec/omniauth/builder_spec.rb
@@ -1,28 +1,6 @@
 require 'helper'
 
 describe OmniAuth::Builder do
-  describe '#initialize' do
-    let(:app) { lambda { |_env| [200, {}, []] } }
-    let(:prok) { proc {} }
-    let(:builder) { OmniAuth::Builder }
-
-    it 'calls original when rack 1.4' do
-      allow(Rack).to receive(:release).and_return('1.4.0')
-
-      expect(builder).to receive(:new).with(app, &prok).and_call_original
-
-      builder.new(app, &prok)
-    end
-
-    it 'calls original when rack 2' do
-      allow(Rack).to receive(:release).and_return('2.0.0')
-
-      expect(builder).to receive(:new).with(app, &prok).and_call_original
-
-      builder.new(app, &prok)
-    end
-  end
-
   describe '#provider' do
     it 'translates a symbol to a constant' do
       expect(OmniAuth::Strategies).to receive(:const_get).with('MyStrategy').and_return(Class.new)

--- a/spec/omniauth/builder_spec.rb
+++ b/spec/omniauth/builder_spec.rb
@@ -9,9 +9,17 @@ describe OmniAuth::Builder do
     it 'calls original when rack 1.4' do
       allow(Rack).to receive(:release).and_return('1.4.0')
 
-      expect(builder).to receive(:new).with(app).and_call_original
+      expect(builder).to receive(:new).with(app, &prok).and_call_original
 
-      builder.new(app)
+      builder.new(app, &prok)
+    end
+
+    it 'calls original when rack 2' do
+      allow(Rack).to receive(:release).and_return('2.0.0')
+
+      expect(builder).to receive(:new).with(app, &prok).and_call_original
+
+      builder.new(app, &prok)
     end
   end
 
@@ -66,9 +74,11 @@ describe OmniAuth::Builder do
     it 'passes the block to the config' do
       prok = proc {}
 
-      OmniAuth::Builder.new(nil).on_failure(&prok)
+      with_config_reset(:on_failure) do
+        OmniAuth::Builder.new(nil).on_failure(&prok)
 
-      expect(OmniAuth.config.on_failure).to eq(prok)
+        expect(OmniAuth.config.on_failure).to eq(prok)
+      end
     end
   end
 
@@ -76,9 +86,11 @@ describe OmniAuth::Builder do
     it 'passes the block to the config' do
       prok = proc {}
 
-      OmniAuth::Builder.new(nil).before_options_phase(&prok)
+      with_config_reset(:before_options_phase) do
+        OmniAuth::Builder.new(nil).before_options_phase(&prok)
 
-      expect(OmniAuth.config.before_options_phase).to eq(prok)
+        expect(OmniAuth.config.before_options_phase).to eq(prok)
+      end
     end
   end
 
@@ -86,9 +98,11 @@ describe OmniAuth::Builder do
     it 'passes the block to the config' do
       prok = proc {}
 
-      OmniAuth::Builder.new(nil).before_request_phase(&prok)
+      with_config_reset(:before_request_phase) do
+        OmniAuth::Builder.new(nil).before_request_phase(&prok)
 
-      expect(OmniAuth.config.before_request_phase).to eq(prok)
+        expect(OmniAuth.config.before_request_phase).to eq(prok)
+      end
     end
   end
 
@@ -96,9 +110,11 @@ describe OmniAuth::Builder do
     it 'passes the block to the config' do
       prok = proc {}
 
-      OmniAuth::Builder.new(nil).before_callback_phase(&prok)
+      with_config_reset(:before_callback_phase) do
+        OmniAuth::Builder.new(nil).before_callback_phase(&prok)
 
-      expect(OmniAuth.config.before_callback_phase).to eq(prok)
+        expect(OmniAuth.config.before_callback_phase).to eq(prok)
+      end
     end
   end
 
@@ -126,5 +142,11 @@ describe OmniAuth::Builder do
 
       expect(app).to have_received(:call).with(env)
     end
+  end
+
+  def with_config_reset(option)
+    old_config = OmniAuth.config.send(option)
+    yield
+    OmniAuth.config.send("#{option}=", old_config)
   end
 end


### PR DESCRIPTION
https://github.com/intridea/hashie/releases/tag/v4.0.0

We released the 4.0.0 release as a major semver change due to multiple non-destructive hash methods being changed to return Mash subclasses instead of plain ol' Ruby hashes. This shouldn't affect the majority of projects, but versioning changes allow projects to choose whether to upgrade or not. 

The other included changes were the result of some yak-shaving I had to do to get CI passing again since it's been failing for 4 months :( 

closes #976