### PR TITLE
Do not restrict maximum version of Hashie.

### DIFF
--- a/omniauth.gemspec
+++ b/omniauth.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'omniauth/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'hashie', ['>= 3.4.6', '~> 4.0.0']
+  spec.add_dependency 'hashie', ['>= 3.4.6']
   spec.add_dependency 'rack', ['>= 1.6.2', '< 3']
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 12.0'


### PR DESCRIPTION
Seeing https://github.com/omniauth/omniauth/pull/977 which fixed the build here, and [seeing that the current hashie master build is broken](https://travis-ci.org/hashie/hashie/jobs/612858905) on an integration spec with Omniauth. 

The only reason to introduce a version restriction for hashie is if you know that a gem is incompatible with a certain version of hashie. Currently we know that omniauth requires hashie >= 3.4.6. There's no need to restrict against a future hashie 5, similarly as there was no need to restrict against hashie 4, which released a while ago and works great with omniauth.