### PR TITLE
simplecov ignore strategy_macros

### DIFF
--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -8,8 +8,7 @@ if RUBY_VERSION >= '1.9'
   ]
 
   SimpleCov.start do
-    add_filter '/spec/'
-    add_filter '/vendor/'
+    add_filter ['/spec/', '/vendor/', 'strategy_macros.rb']
     minimum_coverage(92.5)
   end
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -10,6 +10,7 @@ if RUBY_VERSION >= '1.9'
   SimpleCov.start do
     add_filter ['/spec/', '/vendor/', 'strategy_macros.rb']
     minimum_coverage(92.5)
+    maximum_coverage_drop(0.01)
   end
 end
 


### PR DESCRIPTION
This file is just macros for tests that strategies can use. It seems that coverage in this is flakey, and we don't need it.