### PR TITLE
Dup options when a strategy is dup'd or cloned

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -491,15 +491,14 @@ module OmniAuth
       OmniAuth.config.on_failure.call(env)
     end
 
-    def dup
-      super.tap do
-        @options = @options.dup
-      end
-    end
-
     class Options < OmniAuth::KeyStore; end
 
   protected
+
+    def initialize_copy(*args)
+      super
+      @options = @options.dup
+    end
 
     def merge_stack(stack)
       stack.inject({}) do |a, e|


### PR DESCRIPTION
In multi-threaded environments, we should ensure that Rack middlewares are immutable. The [`rack-freeze`](https://github.com/ioquatix/rack-freeze) gem is small a policy framework that ensures just that. More infos are avaialble in [this article](https://crypt.codemancers.com/posts/2018-06-07-frozen-middleware-with-rack-freeze/). 

This keeps the fix introduced in https://github.com/omniauth/omniauth/pull/829 but also ensures that the base strategy is immutable (and pass `rack-freeze` policy). This matches the original implementation which was apparently abandoned for Ruby 1.8.7 compatibility at the time (https://github.com/omniauth/omniauth/pull/829/commits/fa868a0f0d1e879d18c4beb51a905f3aace1e14c).

Related issue : https://github.com/omniauth/omniauth/issues/940
