### PR TITLE
Remove Hakiri badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Build Status](http://img.shields.io/travis/omniauth/omniauth.svg)][travis]
 [![Code Climate](http://img.shields.io/codeclimate/github/omniauth/omniauth.svg)][codeclimate]
 [![Coverage Status](http://img.shields.io/coveralls/omniauth/omniauth.svg)][coveralls]
-[![Security](https://hakiri.io/github/omniauth/omniauth/master.svg)](https://hakiri.io/github/omniauth/omniauth/master)
 
 [gem]: https://rubygems.org/gems/omniauth
 [travis]: http://travis-ci.org/omniauth/omniauth


### PR DESCRIPTION
This page provides a really glaring notice on the README: 
![image](https://user-images.githubusercontent.com/64050/74679646-5cbcdb80-51b6-11ea-9d83-56daee2d69d0.png)

...except, the latest commits are all warnings/green. The only security issue is from three years ago: 

![image](https://user-images.githubusercontent.com/64050/74679674-7100d880-51b6-11ea-817c-1526e6acad6f.png)

I'm guessing this Hakiri service doesn't really work, considering it also hasn't had an update in three years.
