### PR TITLE
change get to post in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ steps are necessary for your application. For example, in a Rails app I
 would add a line in my `routes.rb` file like this:
 
 ```ruby
-get '/auth/:provider/callback', to: 'sessions#create'
+post '/auth/:provider/callback', to: 'sessions#create'
 ```
 
 And I might then have a `SessionsController` with code that looks


### PR DESCRIPTION
when following the instructions with the developer provider I noticed that I needed to use post