### PR TITLE
Increase test coverage

### DIFF
--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -159,7 +159,7 @@ module OmniAuth
       if first_letter_in_uppercase
         word.to_s.gsub(%r{/(.?)}) { '::' + Regexp.last_match[1].upcase }.gsub(/(^|_)(.)/) { Regexp.last_match[2].upcase }
       else
-        word.first + camelize(word)[1..-1]
+        camelize(word).tap { |w| w[0] = w[0].downcase }
       end
     end
   end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -45,7 +45,7 @@ class ExampleStrategy
 
   def request_phase
     options[:mutate_on_request].call(options) if options[:mutate_on_request]
-    @fail = fail!(options[:failure]) if options[:failure]
+    @fail = fail!(options[:failure], options[:failure_exception]) if options[:failure]
     @last_env = env
     return @fail if @fail
 
@@ -54,7 +54,7 @@ class ExampleStrategy
 
   def callback_phase
     options[:mutate_on_callback].call(options) if options[:mutate_on_callback]
-    @fail = fail!(options[:failure]) if options[:failure]
+    @fail = fail!(options[:failure], options[:failure_exception]) if options[:failure]
     @last_env = env
     return @fail if @fail
 

--- a/spec/omniauth/auth_hash_spec.rb
+++ b/spec/omniauth/auth_hash_spec.rb
@@ -13,6 +13,10 @@ describe OmniAuth::AuthHash do
     expect(subject.weird_field.info).to eq 'string'
   end
 
+  it 'has a subkey_class' do
+    expect(OmniAuth::AuthHash.subkey_class).to eq Hashie::Mash
+  end
+
   describe '#valid?' do
     subject { OmniAuth::AuthHash.new(:uid => '123', :provider => 'example', :info => {:name => 'Steven'}) }
 
@@ -109,6 +113,10 @@ describe OmniAuth::AuthHash do
       it 'is valid if there is a name' do
         expect(OmniAuth::AuthHash::InfoHash.new(:name => 'Awesome')).to be_valid
       end
+    end
+
+    it 'has a subkey_class' do
+      expect(OmniAuth::AuthHash::InfoHash.subkey_class).to eq Hashie::Mash
     end
 
     require 'hashie/version'

--- a/spec/omniauth/form_spec.rb
+++ b/spec/omniauth/form_spec.rb
@@ -7,7 +7,8 @@ describe OmniAuth::Form do
     end
 
     it 'evaluates in the instance when called with a block and no argument' do
-      OmniAuth::Form.build { |f| expect(f.class).to eq(OmniAuth::Form) }
+      f = OmniAuth::Form.build { @html = '<h1>OmniAuth</h1>' }
+      expect(f.instance_variable_get(:@html)).to eq('<h1>OmniAuth</h1>')
     end
   end
 
@@ -18,6 +19,36 @@ describe OmniAuth::Form do
 
     it 'sets an H1 tag from the passed :title option' do
       expect(OmniAuth::Form.new(:title => 'Something Cool').to_html).to be_include('<h1>Something Cool</h1>')
+    end
+  end
+
+  describe '#password_field' do
+    it 'adds a labeled input field' do
+      form = OmniAuth::Form.new.password_field('pass', 'password')
+      form_html = form.to_html
+      expect(form_html).to include('<label for=\'password\'>pass:</label>')
+      expect(form_html).to include('<input type=\'password\' id=\'password\' name=\'password\'/>')
+    end
+  end
+
+  describe '#html' do
+    it 'appends to the html body' do
+      form = OmniAuth::Form.build { @html = '<p></p>' }
+      form.html('<h1></h1>')
+
+      expect(form.instance_variable_get(:@html)).to eq '<p></p><h1></h1>'
+    end
+  end
+
+  describe 'fieldset' do
+    it 'creates a fieldset with options' do
+      form = OmniAuth::Form.new
+      options = {:style => 'color: red', :id => 'fieldSetId'}
+      expected = "<fieldset style='color: red' id='fieldSetId'>\n  <legend>legendary</legend>\n\n</fieldset>"
+
+      form.fieldset('legendary', options) {}
+
+      expect(form.to_html).to include expected
     end
   end
 end

--- a/spec/omniauth/key_store_spec.rb
+++ b/spec/omniauth/key_store_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe OmniAuth::KeyStore do
 
     it 'does not log anything to the console' do
       stub_const('Hashie::VERSION', version)
+      allow(OmniAuth::KeyStore).to receive(:respond_to?).with(:disable_warnings).and_return(false)
       OmniAuth::KeyStore.override_logging
       expect(logger).not_to receive(:info)
       OmniAuth::KeyStore.new(:id => 1234)

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -32,6 +32,12 @@ describe OmniAuth::Strategy do
     end
   end
 
+  describe 'user_info' do
+    it 'should default to an empty hash' do
+      expect(fresh_strategy.new(app, :skip_info => true).user_info).to eq({})
+    end
+  end
+
   describe '.configure' do
     subject do
       c = Class.new
@@ -60,6 +66,29 @@ describe OmniAuth::Strategy do
       subject.configure :abc => {:def => 123}
       subject.configure :abc => {:hgi => 456}
       expect(subject.default_options['abc']).to eq('def' => 123, 'hgi' => 456)
+    end
+  end
+
+  describe '#fail!' do
+    it 'provides exception information when one is provided' do
+      env = make_env
+      exception = RuntimeError.new('No session!')
+
+      expect(OmniAuth.logger).to receive(:error).with(
+        "(test) Authentication failure! failed: #{exception.class}, #{exception.message}"
+      )
+
+      ExampleStrategy.new(app, :failure => :failed, :failure_exception => exception).call(env)
+    end
+
+    it 'provides a generic message when not provided an exception' do
+      env = make_env
+
+      expect(OmniAuth.logger).to receive(:error).with(
+        '(test) Authentication failure! Some Issue encountered.'
+      )
+
+      ExampleStrategy.new(app, :failure => "Some Issue").call(env)
     end
   end
 

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -88,7 +88,7 @@ describe OmniAuth::Strategy do
         '(test) Authentication failure! Some Issue encountered.'
       )
 
-      ExampleStrategy.new(app, :failure => "Some Issue").call(env)
+      ExampleStrategy.new(app, :failure => 'Some Issue').call(env)
     end
   end
 

--- a/spec/omniauth_spec.rb
+++ b/spec/omniauth_spec.rb
@@ -159,6 +159,11 @@ describe OmniAuth do
       it 'doesn\'t uppercase the first letter when passed false' do
         expect(OmniAuth::Utils.camelize('apple_jack', false)).to eq('appleJack')
       end
+
+      it 'replaces / with ::' do
+        expect(OmniAuth::Utils.camelize('apple_jack/cereal')).to eq('AppleJack::Cereal')
+        expect(OmniAuth::Utils.camelize('apple_jack/cereal', false)).to eq('appleJack::Cereal')
+      end
     end
   end
 end

--- a/spec/omniauth_spec.rb
+++ b/spec/omniauth_spec.rb
@@ -128,6 +128,13 @@ describe OmniAuth do
   end
 
   describe '::Utils' do
+    describe 'form_css' do
+      it 'returns a style tag with the configured form_css' do
+        allow(OmniAuth).to receive(:config).and_return(double(:form_css => 'css.css'))
+        expect(OmniAuth::Utils.form_css).to eq "<style type='text/css'>css.css</style>"
+      end
+    end
+
     describe '.deep_merge' do
       it 'combines hashes' do
         expect(OmniAuth::Utils.deep_merge({'abc' => {'def' => 123}}, 'abc' => {'foo' => 'bar'})).to eq('abc' => {'def' => 123, 'foo' => 'bar'})

--- a/spec/omniauth_spec.rb
+++ b/spec/omniauth_spec.rb
@@ -148,6 +148,10 @@ describe OmniAuth do
         OmniAuth.config.add_camelization('oauth', 'OAuth')
         expect(OmniAuth::Utils.camelize(:oauth)).to eq('OAuth')
       end
+
+      it 'doesn\'t uppercase the first letter when passed false' do
+        expect(OmniAuth::Utils.camelize('apple_jack', false)).to eq('appleJack')
+      end
     end
   end
 end


### PR DESCRIPTION
This also fixes a bug I found while increasing the test coverage, where passing `false` as the second param of `OmniAuth::Utils.camelize` would throw an error due to there not being a method `#first` defined for `String`. The old method would also fail since it would turn 
`camelize('apple_jacks', false)` to `"aPpleJacks"`, now it will correctly do `"appleJacks"`