### PR TITLE
Test against Ruby 2.6.6 and 2.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ rvm:
   - 2.3.5
   - 2.4.4
   - 2.5.3
+  - 2.6.6
+  - 2.7.1
   - jruby-head
   - ruby-head
 matrix:


### PR DESCRIPTION
People use OmniAuth with new Rubys and we need tests for them.