### PR TITLE
Update: Bump json gem to 2.3 for ruby 2.7 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ end
 group :test do
   gem 'coveralls', :require => false
   gem 'hashie', '>= 3.4.6', '~> 4.0.0', :platforms => [:jruby_18]
-  gem 'json', '~> 2.0.3', :platforms => %i[jruby_18 jruby_19 ruby_19]
+  gem 'json', '~> 2.3.0', :platforms => %i[jruby_18 jruby_19 ruby_19]
   gem 'mime-types', '~> 3.1', :platforms => [:jruby_18]
   gem 'rack', '>= 2.0.6', :platforms => %i[jruby_18 jruby_19 ruby_19 ruby_20 ruby_21]
   gem 'rack-test'


### PR DESCRIPTION
given ruby 2.7 support added in #1002

silence deprecation warning for ruby 2.7.1 - see: https://travis-ci.org/github/omniauth/omniauth/jobs/683231570

```
/home/travis/.rvm/gems/ruby-2.7.1/gems/json-2.0.4/lib/json/common.rb:156: warning: Using the last argument as keyword parameters is deprecated
```

updated Nov-19 in json gem: https://github.com/flori/json/pull/389/files#diff-1fb83c48ff17d82315a53e5f26bc4996R156

diff: https://github.com/flori/json/compare/v2.0.3...v2.3.0