### PR TITLE
RFC - Make omniauth use post by default

### DIFF
--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -15,6 +15,7 @@ module OmniAuth
   autoload :Form,     'omniauth/form'
   autoload :AuthHash, 'omniauth/auth_hash'
   autoload :FailureEndpoint, 'omniauth/failure_endpoint'
+  autoload :AuthenticityTokenProtection, 'omniauth/authenticity_token_protection'
 
   def self.strategies
     @strategies ||= []
@@ -29,20 +30,22 @@ module OmniAuth
       logger
     end
 
-    def self.defaults
+    def self.defaults # rubocop:disable MethodLength
       @defaults ||= {
         :camelizations => {},
         :path_prefix => '/auth',
         :on_failure => OmniAuth::FailureEndpoint,
         :failure_raise_out_environments => ['development'],
+        :request_validation_phase => OmniAuth::AuthenticityTokenProtection,
         :before_request_phase   => nil,
         :before_callback_phase  => nil,
         :before_options_phase   => nil,
         :form_css => Form::DEFAULT_CSS,
         :test_mode => false,
         :logger => default_logger,
-        :allowed_request_methods => %i[get post],
-        :mock_auth => {:default => AuthHash.new('provider' => 'default', 'uid' => '1234', 'info' => {'name' => 'Example User'})}
+        :allowed_request_methods => %i[post],
+        :mock_auth => {:default => AuthHash.new('provider' => 'default', 'uid' => '1234', 'info' => {'name' => 'Example User'})},
+        :silence_get_warning => false
       }
     end
 
@@ -71,6 +74,14 @@ module OmniAuth
         @before_options_phase = block
       else
         @before_options_phase
+      end
+    end
+
+    def request_validation_phase(&block)
+      if block_given?
+        @request_validation_phase = block
+      else
+        @request_validation_phase
       end
     end
 
@@ -111,8 +122,9 @@ module OmniAuth
       camelizations[name.to_s] = camelized.to_s
     end
 
-    attr_writer :on_failure, :before_callback_phase, :before_options_phase, :before_request_phase
-    attr_accessor :failure_raise_out_environments, :path_prefix, :allowed_request_methods, :form_css, :test_mode, :mock_auth, :full_host, :camelizations, :logger
+    attr_writer :on_failure, :before_callback_phase, :before_options_phase, :before_request_phase, :request_validation_phase
+    attr_accessor :failure_raise_out_environments, :path_prefix, :allowed_request_methods, :form_css,
+                  :test_mode, :mock_auth, :full_host, :camelizations, :logger, :silence_get_warning
   end
 
   def self.config

--- a/lib/omniauth/authenticity_token_protection.rb
+++ b/lib/omniauth/authenticity_token_protection.rb
@@ -1,0 +1,30 @@
+require 'rack-protection'
+
+module OmniAuth
+  class AuthenticityError < StandardError; end
+  class AuthenticityTokenProtection < Rack::Protection::AuthenticityToken
+    def initialize(options = {})
+      @options = default_options.merge(options)
+    end
+
+    def self.call(env)
+      new.call!(env)
+    end
+
+    def call!(env)
+      return if accepts?(env)
+
+      instrument env
+      react env
+    end
+
+  private
+
+    def deny(_env)
+      OmniAuth.logger.send(:warn, "Attack prevented by #{self.class}")
+      raise AuthenticityError.new(options[:message])
+    end
+
+    alias default_reaction deny
+  end
+end

--- a/omniauth.gemspec
+++ b/omniauth.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hashie', ['>= 3.4.6']
   spec.add_dependency 'rack', ['>= 1.6.2', '< 3']
   spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_dependency 'rack-protection'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.authors       = ['Michael Bleigh', 'Erik Michaels-Ober', 'Tom Milewski']
   spec.description   = 'A generalized Rack framework for multiple-provider authentication.'

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -24,6 +24,7 @@ require 'omniauth'
 require 'omniauth/test'
 
 OmniAuth.config.logger = Logger.new('/dev/null')
+OmniAuth.config.request_validation_phase = nil
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods

--- a/spec/omniauth/strategies/developer_spec.rb
+++ b/spec/omniauth/strategies/developer_spec.rb
@@ -10,7 +10,7 @@ describe OmniAuth::Strategies::Developer do
   end
 
   context 'request phase' do
-    before(:each) { get '/auth/developer' }
+    before(:each) { post '/auth/developer' }
 
     it 'displays a form' do
       expect(last_response.status).to eq(200)

--- a/spec/omniauth_spec.rb
+++ b/spec/omniauth_spec.rb
@@ -26,20 +26,22 @@ describe OmniAuth do
     end
 
     before do
-      @old_path_prefix           = OmniAuth.config.path_prefix
-      @old_on_failure            = OmniAuth.config.on_failure
-      @old_before_callback_phase = OmniAuth.config.before_callback_phase
-      @old_before_options_phase  = OmniAuth.config.before_options_phase
-      @old_before_request_phase  = OmniAuth.config.before_request_phase
+      @old_path_prefix              = OmniAuth.config.path_prefix
+      @old_on_failure               = OmniAuth.config.on_failure
+      @old_before_callback_phase    = OmniAuth.config.before_callback_phase
+      @old_before_options_phase     = OmniAuth.config.before_options_phase
+      @old_before_request_phase     = OmniAuth.config.before_request_phase
+      @old_request_validation_phase = OmniAuth.config.request_validation_phase
     end
 
     after do
       OmniAuth.configure do |config|
-        config.path_prefix           = @old_path_prefix
-        config.on_failure            = @old_on_failure
-        config.before_callback_phase = @old_before_callback_phase
-        config.before_options_phase  = @old_before_options_phase
-        config.before_request_phase  = @old_before_request_phase
+        config.path_prefix              = @old_path_prefix
+        config.on_failure               = @old_on_failure
+        config.before_callback_phase    = @old_before_callback_phase
+        config.before_options_phase     = @old_before_options_phase
+        config.before_request_phase     = @old_before_request_phase
+        config.request_validation_phase = @old_request_validation_phase
       end
     end
 
@@ -86,6 +88,15 @@ describe OmniAuth do
         end
       end
       expect(OmniAuth.config.before_callback_phase.call).to eq('heyhey')
+    end
+
+    it 'is able to set request_validation_phase' do
+      OmniAuth.configure do |config|
+        config.request_validation_phase do
+          'validated'
+        end
+      end
+      expect(OmniAuth.config.request_validation_phase.call).to eq('validated')
     end
 
     describe 'mock auth' do


### PR DESCRIPTION
Re:
https://github.com/omniauth/omniauth/issues/960
https://github.com/omniauth/omniauth/pull/809

Shoutout @pat, this work was influenced by https://github.com/omniauth/omniauth/pull/963

This would obviously need to be a major version bump due to breaking changes. 

This is based on the ideas of a few others, with some things I added in myself. 

The changes include:  
- Defaulting to POST only allowed request methods
- Use of a `request_validation_phase` specific to this type of workflow. 
- Default request validation phase that should work for _most_ rack based apps, though Rails is a special case 

Example apps available [here](https://github.com/BobbyMcWho/omniauth_2_examples). 

Rails apps will require a special [verification phase](https://github.com/BobbyMcWho/omniauth_2_examples/blob/main/rails_app.ru#L14-L28) that they [config](https://github.com/BobbyMcWho/omniauth_2_examples/blob/main/rails_app.ru#L34) in an initializer (or elsewhere if using devise). 

Seeking feedback and reviews, hoping I didn't miss anything glaringly obvious here. 