### PR TITLE
use ruby 2.4 in matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby: [2.5, 2.6, 2.7, head, debug, truffleruby, truffleruby-head]
+        ruby: [2.4, 2.5, 2.6, 2.7, head, debug, truffleruby, truffleruby-head]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development do
 end
 
 group :test do
-  gem 'coveralls_reborn', '~> 0.19.0', require: false
+  gem 'coveralls_reborn', '~> 0.19.0', :require => false
   gem 'hashie', '>= 3.4.6', '~> 4.0.0', :platforms => [:jruby_18]
   gem 'json', '~> 2.3.0', :platforms => %i[jruby_18 jruby_19 ruby_19]
   gem 'mime-types', '~> 3.1', :platforms => [:jruby_18]


### PR DESCRIPTION
Ruby 2.4 is no longer officially supported, but omniauth's Ruby support is 2.2 and above, so I've also added tests for Ruby 2.4 to GitHub Actions.