### PR TITLE
Allow OmniAuthAuthenticityTokenProtection options to be configured

### DIFF
--- a/lib/omniauth/authenticity_token_protection.rb
+++ b/lib/omniauth/authenticity_token_protection.rb
@@ -18,6 +18,8 @@ module OmniAuth
       react env
     end
 
+    alias_method :call, :call!
+
   private
 
     def deny(_env)

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -973,6 +973,19 @@ describe OmniAuth::Strategy do
         end
       end
 
+      context 'with custom allow_if proc' do
+        before do
+          OmniAuth.config.request_validation_phase = OmniAuth::AuthenticityTokenProtection.new(allow_if: ->(env) { true })
+        end
+
+        it 'allows a valid request' do
+          expect(strategy).to receive(:fail!).with('Request Phase', kind_of(StandardError))
+
+          post_env = make_env('/auth/test')
+          strategy.call(post_env)
+        end
+      end
+
       after do
         OmniAuth.config.request_validation_phase = nil
       end


### PR DESCRIPTION
This will be useful for disabling csrf protection in test suites or configuring the csrf key when the next version of rack-protection is released.

ie:

```
OmniAuth.config.request_validation_phase = OmniAuth::AuthenticityTokenProtection.new(allow_if: ->(env) { true })
```

or

```
OmniAuth.config.request_validation_phase = OmniAuth::AuthenticityTokenProtection.new(key: :_csrf_token)
```