### PR TITLE
Ensure mock call verifies authenticity tokens with same logic as real call

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -299,7 +299,6 @@ module OmniAuth
     # in test mode.
     def mock_call!(*)
       begin
-        OmniAuth.config.request_validation_phase.call(env) if OmniAuth.config.request_validation_phase
         return mock_request_call if on_request_path? && OmniAuth.config.allowed_request_methods.include?(request.request_method.downcase.to_sym)
         return mock_callback_call if on_callback_path?
       rescue StandardError => e
@@ -313,7 +312,10 @@ module OmniAuth
       setup_phase
 
       session['omniauth.params'] = request.GET
+
+      OmniAuth.config.request_validation_phase.call(env) if OmniAuth.config.request_validation_phase
       OmniAuth.config.before_request_phase.call(env) if OmniAuth.config.before_request_phase
+
       if options.origin_param
         if request.params[options.origin_param]
           session['omniauth.origin'] = request.params[options.origin_param]

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -1001,6 +1001,26 @@ describe OmniAuth::Strategy do
       OmniAuth.config.test_mode = false
       expect(strategy.call(make_env).first).to eq 302
     end
+
+    context 'when in test mode and path not on request path' do
+      let(:path) { '/foo/bar' }
+
+      before do
+        OmniAuth.config.test_mode = true
+        OmniAuth.config.request_validation_phase = OmniAuth::AuthenticityTokenProtection
+        allow(OmniAuth::AuthenticityTokenProtection).to receive(:call).and_raise(OmniAuth::AuthenticityError)
+      end
+
+      it 'does not verify token' do
+        expect(strategy).not_to receive(:fail!)
+        strategy.call(make_env(path))
+      end
+
+      after do
+        OmniAuth.config.test_mode = false
+        OmniAuth.config.request_validation_phase = false
+      end
+    end
   end
 
   context 'setup phase' do


### PR DESCRIPTION
Readjusts when the authenticity token verification happens in `#mock_call` to align with the execution of the real call.

## Purpose

The current implementation of `mock_call` was verifying the token for all requests, regardless of whether the current path is on the omniauth request path. The change was introduced recently in https://github.com/omniauth/omniauth/commit/1b784ffa5f128bea1a22d7d26477f73bb6b3cd08. See https://github.com/omniauth/omniauth/issues/1032 for details.

This creates two problems:

1. When test mode is on, the authenticity verification logic is run inappropriately against requests where this may not even be wanted.
2. The behavior varies from actual production behavior, potentially allowing bugs to be introduced by unwary developers.

## Approach

* Move the request validation logic into `#mock_request_call `so that it tracks more closely with the real validation logic that is triggered from `#request_call`.
* Add a spec test to capture the regression

Please feel free to introduce this change in a different manner if needed. My main interest is unblocking a project I have where the newly introduced logic change is breaking many tests. We are disabling the `request_validation_phase` in all tests, but would like to re-enable it for integration tests to ensure our tests specify the behavior correctly.