### PR TITLE
Better handle errors that come from the actual app.

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -193,6 +193,8 @@ module OmniAuth
         return callback_call if on_callback_path?
         return other_phase if respond_to?(:other_phase)
       rescue StandardError => e
+        raise e if env.delete('omniauth.error.app')
+
         return fail!(e.message, e)
       end
 
@@ -302,6 +304,8 @@ module OmniAuth
         return mock_request_call if on_request_path? && OmniAuth.config.allowed_request_methods.include?(request.request_method.downcase.to_sym)
         return mock_callback_call if on_callback_path?
       rescue StandardError => e
+        raise e if env.delete('omniauth.error.app')
+
         return fail!(e.message, e)
       end
 
@@ -462,6 +466,9 @@ module OmniAuth
 
     def call_app!(env = @env)
       @app.call(env)
+    rescue StandardError => e
+      env['omniauth.error.app'] = true
+      raise e
     end
 
     def full_host


### PR DESCRIPTION
As a consequence of the changes that were merged in #689, errors
thrown by strategies that utilize other_phase (or more specifically
call_app!), would be caught by omniauth, causing headaches for folks
looking to have those errors handled by their application. This
should allow for errors that come from the app to pass through, while
passing errors that come from the authentication phases to the fail!
handler.

Resolves #1030