### PR TITLE
Warn only on GET requests for a login path

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -180,9 +180,10 @@ module OmniAuth
         raise(error)
       end
 
-      warn_if_using_get
-
       @env = env
+
+      warn_if_using_get_on_request_path
+
       @env['omniauth.strategy'] = self if on_auth_path?
 
       return mock_call!(env) if OmniAuth.config.test_mode
@@ -201,7 +202,8 @@ module OmniAuth
       @app.call(env)
     end
 
-    def warn_if_using_get
+    def warn_if_using_get_on_request_path
+      return unless on_request_path?
       return unless OmniAuth.config.allowed_request_methods.include?(:get)
       return if OmniAuth.config.silence_get_warning
 


### PR DESCRIPTION
This is a fix for warning logging brought up in https://github.com/omniauth/omniauth/pull/1010#discussion_r604382856

The problem is that currently warning message is logged on *every* GET request, not only for a login path. Such messages can bloat application logs very fast

Also, it contradicts this particular piece of documentation ([source](https://github.com/omniauth/omniauth/wiki/Upgrading-to-2.0#get)):

> Because using GET for login poses concerns (see OWASP Cheatsheet), after upgrading OmniAuth **will log a :warn level log with every GET request to a login path** when your OmniAuth.config.allowed_request_methods include :get.