### PR TITLE
Ignore query params when we check current_path

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -290,7 +290,9 @@ module OmniAuth
       on_path?(callback_path)
     end
 
+    # Compare paths, ignoring case and query params
     def on_path?(path)
+      path = path.to_s[/\A[^\?]*/]
       current_path.casecmp(path).zero?
     end
 


### PR DESCRIPTION
This addresses an issue raised a few times.
https://github.com/omniauth/omniauth/issues/661
https://github.com/omniauth/omniauth/issues/767

This change will allow a user to provide a callback_path that
includes a query param.

Now, for example:
`users/auth/github/callback` will match
`users/auth/github/callback?role=admin`