### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ example that you might put into a Rails initializer at
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :developer unless Rails.env.production?
+  unless Rails.env.production?
+    provider :developer
+    OmniAuth.config.allowed_request_methods = [:get, :post]
+  end
   provider :twitter, ENV['TWITTER_KEY'], ENV['TWITTER_SECRET']
 end
 ```


### PR DESCRIPTION
I spent an hour trying to figure out why `/auth/developer` wasn't working from the README, and its because the `:get` method wasn't allowed for `OmniAuth.config.allowed_request_methods`

Is there a better way to do this per provider instead of globally for all providers? That would be ideal, but if not, what's the danger of adding `:get` to the default list vs the change I'm proposing?

Regardless of the path, this change will prevent future devs from spending lots of time trying to figure out why `/auth/developer` doesn't work.