### PR TITLE
docs: Add CSRF protection section

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ OmniAuth::AuthenticityTokenProtection.default_options(
 
 It's worth mentioning that `Rack::Protection::AuthenticityToken` encodes/decodes the CSRF token in base64, in the case you are using a different approach you will need to use the `allow_if` option and implement the allow/deny logic yourself.
 
-See the [documentation](https://www.rubydoc.info/gems/rack-protection/Rack/Protection/AuthenticityToken) for more details.
+See the [rack-protection documentation](https://www.rubydoc.info/gems/rack-protection/Rack/Protection/AuthenticityToken) for more details.
 
 ## Rails (without Devise)
 To get started, add the following gems


### PR DESCRIPTION
Add a generic section about CSRF protection, to describe how it's implemented in OmniAuth and how to configure it.

References:
- #1069
- #1074