### PR TITLE
Use the session method in OmniAuth::Strategy

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -250,9 +250,9 @@ module OmniAuth
         request_phase
       else
         if request.params[options.origin_param]
-          env['rack.session']['omniauth.origin'] = request.params[options.origin_param]
+          session['omniauth.origin'] = request.params[options.origin_param]
         elsif env['HTTP_REFERER'] && !env['HTTP_REFERER'].match(/#{request_path}$/)
-          env['rack.session']['omniauth.origin'] = env['HTTP_REFERER']
+          session['omniauth.origin'] = env['HTTP_REFERER']
         end
 
         request_phase


### PR DESCRIPTION
## Context

In our Rails application we use `omniauth_openid_connect (0.4.0)` to perform an OpenID Connect authentication flow. We want to override the session mechanism to store omniauth related attributes in a dedicated cookie (other session attributes remain in the regular session state).

For that purpose, in our application we create a subclass of `OmniAuth::Strategies::OpenIDConnect` which overrides the `OmniAuth::Strategy.session` method. Our implementation of the `session` method provides a wrapper that stores `omniauth*` attributes in a dedicated secured cookie.

## Problem

By overriding `OmniAuth::Strategy.session`, we expected to be able to implement a custom session mechanism but it is not possible :

Problem we have, is that `OmniAuth::Strategy` both uses `OmniAuth::Strategy.session` and `env['rack.session']` ([here](https://github.com/omniauth/omniauth/blob/master/lib/omniauth/strategy.rb#L253) and [here](https://github.com/omniauth/omniauth/blob/master/lib/omniauth/strategy.rb#L255)). 

Because `OmniAuth::Strategy` directly accesses `env['rack.session']` without using its `session` method, we cannot inject the expected custom mechanism.

## Suggested solution

In this PR we replace direct usages of `env['rack.session']` by the `session` method in `OmniAuth::Strategy`. 

It still leaves some questions : 

- The same change was introduced by https://github.com/omniauth/omniauth/pull/818, but it only touched the `mock_call!` method. Method `request_call` has not been touched, is there a rational behind this ?

- We cannot replace direct usage of `env['rack.session']` [here](https://github.com/omniauth/omniauth/blob/master/lib/omniauth/strategy.rb#L178) by a call to `session` because `@env` is not set yet. Maybe we should also set `@env` before checking that the session exists ?

```Ruby
@env = env

unless session
   error = OmniAuth::NoSessionError.new('You must provide a session to use OmniAuth.')
   raise(error)
end
```

- Would replacing `env['rack.session']` by `session` break some kind of 'contracts' or encapsulation mechanisms with other omniauth strategies that subclass `OmniAuth::Strategy` ?

Thank you.




