### PR TITLE
Fix Rails getting started example

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,13 +133,15 @@ all up using routes, a controller and a login view.
 **config/routes.rb**:
 
 ```ruby
-  get 'auth/:provider/callback', to: 'sessions#create'
+  post 'auth/:provider/callback', to: 'sessions#create'
   get '/login', to: 'sessions#new'
 ```
 
 **app/controllers/sessions_controller.rb**:
 ```ruby
 class SessionsController < ApplicationController
+  protect_from_forgery with: :null_session, only: [:create]
+
   def new
     render :new
   end


### PR DESCRIPTION
I needed to apply these changes to get omniauth running successfully in my development environment.

- The change from GET to POST was required simply because the `developer` strategy uses a POST method. Without the change I received an obvious `No route matches [POST] "/auth/developer/callback"` error.
- Adding the call to `protect_from_forgery` is required to avoid a `Can't verify CSRF token authenticity.` error

