### PR TITLE
Change Builder from a class to a module and only build app once

### DIFF
--- a/lib/omniauth/builder.rb
+++ b/lib/omniauth/builder.rb
@@ -1,5 +1,13 @@
+require 'rack/builder'
+
 module OmniAuth
-  class Builder < ::Rack::Builder
+  module Builder
+    def self.new app, &block
+      builder = Rack::Builder.new(app).extend(self)
+      builder.instance_eval(&block) if block_given?
+      builder.to_app
+    end
+
     def on_failure(&block)
       OmniAuth.config.on_failure = block
     end
@@ -38,10 +46,6 @@ module OmniAuth
       end
 
       use middleware, *args, **options.merge(opts), &block
-    end
-
-    def call(env)
-      to_app.call(env)
     end
   end
 end


### PR DESCRIPTION
Previously, OmniAuth::Builder was a subclass of Rack::Builder. Rack::Builder#call calls #to_app, rebuilding the Rack application on each request, and, as it says in the Rack::Builder comments, this may have a negative impact on performance.

This commit changes OmniAuth::Builder from a class to a module and defines a ::new method that extends a Rack::Builder instance with that module, instance_evals any block, and returns the value of #to_app, the built application.

Using OmniAuth::Builder will now only build the application once.

For users who have been subclassing OmniAuth::Builder, a fix would be subclassing Rack::Builder directly and including OmniAuth::Builder:

    class MyBuilder < Rack::Builder
      include OmniAuth::Builder
      # ...
    end

Resolves #1083.