### PR TITLE
Fix `bundle install` step on CI for TruffleRuby

### DIFF
--- a/.github/workflows/truffle_ruby.yml
+++ b/.github/workflows/truffle_ruby.yml
@@ -19,7 +19,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
     - name: Install dependencies
       run: bundle install
     - name: Run tests


### PR DESCRIPTION
Currently CI builds agains TruffleRuby 22.3.1 are failed on the `bundle install` step.
```
...
Fetching webrick 1.7.0
  Installing webrick 1.7.0
  Fetching yard 0.9.28
  Installing yard 0.9.28
  --- ERROR REPORT TEMPLATE -------------------------------------------------------
  
...
  NoMethodError: undefined method `full_name' for nil:NilClass
    /home/runner/.rubies/truffleruby-22.3.0/lib/mri/bundler/installer/parallel_installer.rb:124:in `block (2 levels) in check_for_unmet_dependencies'
    /home/runner/.rubies/truffleruby-22.3.0/lib/mri/bundler/installer/parallel_installer.rb:123:in `each'
    /home/runner/.rubies/truffleruby-22.3.0/lib/mri/bundler/installer/parallel_installer.rb:123:in `block in check_for_unmet_dependencies'
    /home/runner/.rubies/truffleruby-22.3.0/lib/mri/bundler/installer/parallel_installer.rb:122:in `each'
    /home/runner/.rubies/truffleruby-22.3.0/lib/mri/bundler/installer/parallel_installer.rb:122:in `check_for_unmet_dependencies'
    /home/runner/.rubies/truffleruby-22.3.0/lib/mri/bundler/installer/parallel_installer.rb:[100](https://github.com/omniauth/omniauth/actions/runs/3970157787/jobs/6805553917#step:3:106):in `call'
    /home/runner/.rubies/truffleruby-22.3.0/lib/mri/bundler/installer/parallel_installer.rb:71:in `call'
    /home/runner/.rubies/truffleruby-22.3.0/lib/mri/bundler/installer.rb:262:in `install_in_parallel'
    /home/runner/.rubies/truffleruby-22.3.0/lib/mri/bundler/installer.rb:209:in `install'
    /home/runner/.rubies/truffleruby-22.3.0/lib/mri/bundler/installer.rb:89:in `block in run'
    /home/runner/.rubies/truffleruby-22.3.0/lib/mri/bundler/process_lock.rb:12:in `block in lock'
    <internal:core> core/io.rb:670:in `open'
```
https://github.com/omniauth/omniauth/actions/runs/3970157787/jobs/6805553917

 I assume that the issue is related to invalid/incorrect cached `Gemfile.lock` file as far as locally I cannot reproduce the issue.

Removing `bundler-cache: true` option in the TruffleRuby workflow solves the issue.

I tried also to invalidate cache with `cache-version` option (https://github.com/ruby/setup-ruby#dealing-with-a-corrupted-cache) but it seems it doesn't work as I expected. My attempts are available in a fork repository https://github.com/andrykonchin/omniauth.