### PR TITLE
Fix specs on CI against TruffleRuby 22.3.1

### DIFF
--- a/.github/workflows/truffle_ruby.yml
+++ b/.github/workflows/truffle_ruby.yml
@@ -19,6 +19,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler: latest
     - name: Install dependencies
       run: bundle install
     - name: Run tests

--- a/.github/workflows/truffle_ruby.yml
+++ b/.github/workflows/truffle_ruby.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Changes:
- use the latest `bundler` version

It should be merged after https://github.com/omniauth/omniauth/pull/1104 to not force using an old `bundler` version

### Notes

Looks like there was an issue in `bundler` version vendored with TruffleRuby 22.3.1.

It leads to spec failures on omniauth CI ([build](https://github.com/omniauth/omniauth/actions/runs/4205385104/jobs/7298340176)):

```
An error occurred while loading ./spec/omniauth/auth_hash_spec.rb. - Did you mean?
                    rspec ./spec/omniauth/strategy_spec.rb
                    rspec ./spec/omniauth/builder_spec.rb

Failure/Error: require 'hashie/mash'

LoadError:
  cannot load such file -- hashie/mash
# ./lib/omniauth/key_store.rb:1:in `<top (required)>'
# ./lib/omniauth/auth_hash.rb:1:in `<top (required)>'
# ./lib/omniauth.rb:4[7](https://github.com/omniauth/omniauth/actions/runs/4205385104/jobs/7298340176#step:5:8):in `defaults'
# ./lib/omniauth.rb:53:in `initialize'
# /home/runner/.rubies/truffleruby-22.3.1/lib/mri/singleton.rb:[12](https://github.com/omniauth/omniauth/actions/runs/4205385104/jobs/7298340176#step:5:13)7:in `block in instance'
# /home/runner/.rubies/truffleruby-22.3.1/lib/mri/singleton.rb:125:in `synchronize'
# /home/runner/.rubies/truffleruby-22.3.1/lib/mri/singleton.rb:125:in `instance'
# ./lib/omniauth.rb:[13](https://github.com/omniauth/omniauth/actions/runs/4205385104/jobs/7298340176#step:5:14)1:in `config'
# ./spec/helper.rb:27:in `<top (required)>'
# ./spec/omniauth/auth_hash_spec.rb:1:in `<top (required)>'
```

The issue looks like was fixed in `bundler` and running specs with current version works fine.
