### PR TITLE
   Use GET with :developer strategy.

### DIFF
--- a/lib/omniauth/form.rb
+++ b/lib/omniauth/form.rb
@@ -7,6 +7,7 @@ module OmniAuth
     def initialize(options = {})
       options[:title] ||= 'Authentication Info Required'
       options[:header_info] ||= ''
+      options[:method] ||= 'post'
       self.options = options
 
       @html = +'' # unary + string allows it to be mutable if strings are frozen
@@ -75,7 +76,7 @@ module OmniAuth
       </head>
       <body>
       <h1>#{title}</h1>
-      <form method='post' #{"action='#{options[:url]}' " if options[:url]}noValidate='noValidate'>
+      <form method='#{options[:method]}' #{"action='#{options[:url]}' " if options[:url]}noValidate='noValidate'>
       HTML
       self
     end

--- a/lib/omniauth/strategies/developer.rb
+++ b/lib/omniauth/strategies/developer.rb
@@ -35,7 +35,7 @@ module OmniAuth
       option :uid_field, :email
 
       def request_phase
-        form = OmniAuth::Form.new(:title => 'User Info', :url => callback_path)
+        form = OmniAuth::Form.new(:title => 'User Info', :url => callback_path, :method => 'get')
         options.fields.each do |field|
           form.text_field field.to_s.capitalize.tr('_', ' '), field.to_s
         end

--- a/spec/omniauth/form_spec.rb
+++ b/spec/omniauth/form_spec.rb
@@ -20,6 +20,14 @@ describe OmniAuth::Form do
     it 'sets an H1 tag from the passed :title option' do
       expect(OmniAuth::Form.new(:title => 'Something Cool').to_html).to be_include('<h1>Something Cool</h1>')
     end
+
+    it 'sets the default form method to post' do
+      expect(OmniAuth::Form.new.to_html).to be_include("method='post'")
+    end
+
+    it 'sets the form method to the passed :method option' do
+      expect(OmniAuth::Form.new(:method => 'get').to_html).to be_include("method='get'")
+    end
   end
 
   describe '#password_field' do

--- a/spec/omniauth/strategies/developer_spec.rb
+++ b/spec/omniauth/strategies/developer_spec.rb
@@ -31,7 +31,7 @@ describe OmniAuth::Strategies::Developer do
 
     context 'with default options' do
       before do
-        post '/auth/developer/callback', :name => 'Example User', :email => 'user@example.com'
+        get '/auth/developer/callback', :name => 'Example User', :email => 'user@example.com'
       end
 
       it 'sets the name in the auth hash' do
@@ -58,7 +58,7 @@ describe OmniAuth::Strategies::Developer do
 
       before do
         @options = {:uid_field => :last_name, :fields => %i[first_name last_name]}
-        post '/auth/developer/callback', :first_name => 'Example', :last_name => 'User'
+        get '/auth/developer/callback', :first_name => 'Example', :last_name => 'User'
       end
 
       it 'sets info fields properly' do


### PR DESCRIPTION
   This changes the default method of the :developer strategy to GET. It does
   this by allowing OmniAuth::Form to accept a `:method` option, which is
   optional and defaults to 'post', the current behavior. Because the default
   behavior remains unchanged, I don't expect this to introduct any breaking
   changes.

   This allows the developer strategy to work with the directions provided in
   the README. Further, it seems that the default action of most stratigies is
   to use GET for their callbacks.

   Fixes #1087 Fixes #1061 Fixes #957