### PR TITLE
Add inspect to raise

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ class SessionsController < ApplicationController
 
   def create
     user_info = request.env['omniauth.auth']
-    raise user_info # Your own session management should be placed here.
+    raise user_info.inspect # Your own session management should be placed here.
   end
 end
 ```


### PR DESCRIPTION
Without inspect we are getting the following error:

```
TypeError (exception class/object expected):

app/controllers/sessions_controller.rb:8:in `raise'
```

Whereas with inspect we are seeing the object:

```
#<OmniAuth::AuthHash credentials=#<OmniAuth::AuthHash expires=false token="XXX"> extra=#<OmniAuth::AuthHash bot_info=
```