### PR TITLE
ci: use ubuntu-latest runner

### DIFF
--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -20,10 +20,8 @@ jobs:
       with:
         ruby-version: ${{ matrix.jruby }}
         bundler-cache: true
-    - name: Install dependencies
       env:
         JRUBY_OPTS: --debug
-      run: bundle install
     - name: Run tests
       env:
         JRUBY_OPTS: --debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
@@ -33,7 +33,7 @@ jobs:
     - name: Run tests
       run: bundle exec rake
   frozen-string-compat:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -48,7 +48,7 @@ jobs:
         RUBYOPT: "--enable-frozen-string-literal"
       run: bundle exec rake
   coveralls:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: Install dependencies
-      run: bundle install
     - name: Run tests
       run: bundle exec rake
   frozen-string-compat:
@@ -41,8 +39,6 @@ jobs:
       with:
         ruby-version: 2.6
         bundler-cache: true
-    - name: Install dependencies
-      run: bundle install
     - name: Run tests
       env:
         RUBYOPT: "--enable-frozen-string-literal"
@@ -56,8 +52,6 @@ jobs:
       with:
         ruby-version: 2.6
         bundler-cache: true
-    - name: Install dependencies
-      run: bundle install
     - name: Run tests
       run: bundle exec rake
     - name: Coveralls GitHub Action

--- a/.github/workflows/truffle_ruby.yml
+++ b/.github/workflows/truffle_ruby.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/truffle_ruby.yml
+++ b/.github/workflows/truffle_ruby.yml
@@ -19,7 +19,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: true
     - name: Run tests
       run: bundle exec rake


### PR DESCRIPTION
The 18.04 runners are depriciated https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/
I noticed some of the jobs had OS matrixes, but they weren't wired in, so I updated them to actually use those runner