### PR TITLE
chore: add Dependabot for version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 99
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 99

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu, macos]
         jruby: [jruby] # TODO: Add back jruby-head once we figure out why there's a bundler mismatch
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         os: [ubuntu, macos]
         ruby: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2, head, debug]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -33,7 +33,7 @@ jobs:
   frozen-string-compat:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -46,7 +46,7 @@ jobs:
   coveralls:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Run tests
       run: bundle exec rake
     - name: Coveralls GitHub Action
-      uses: coverallsapp/github-action@v1.1.2
+      uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.github_token }}
         path-to-lcov: './coverage/lcov/omniauth.lcov'

--- a/.github/workflows/truffle_ruby.yml
+++ b/.github/workflows/truffle_ruby.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu, macos]
         ruby: [truffleruby, truffleruby-head]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Noticed some of the CI actions were behind, so adding Dependabot to keep them up-to-date automatically through PRs