### PR TITLE
chore: Remove conditions for old (J)Ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,16 +13,11 @@ end
 
 group :test do
   gem 'coveralls_reborn', '~> 0.19.0', require: false
-  gem 'hashie', '>= 3.4.6', '~> 4.0.0', platforms: [:jruby_18]
-  gem 'json', '~> 2.3.0', platforms: %i[jruby_18 jruby_19 ruby_19]
-  gem 'mime-types', '~> 3.1', platforms: [:jruby_18]
   gem 'rack-test'
-  gem 'rest-client', '~> 2.0.0', platforms: [:jruby_18]
   gem 'rspec', '~> 3.5'
   gem 'rack-freeze'
-  gem 'rubocop', '>= 0.58.2', '< 0.69.0', platforms: %i[ruby_20 ruby_21 ruby_22 ruby_23 ruby_24]
+  gem 'rubocop', '>= 0.58.2', '< 0.69.0', platforms: %i[ruby_22 ruby_23 ruby_24]
   gem 'simplecov-lcov'
-  gem 'tins', '~> 1.13', platforms: %i[jruby_18 jruby_19 ruby_19]
 end
 
 gemspec

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,21 +1,19 @@
-if RUBY_VERSION >= '1.9'
-  require 'simplecov'
-  require 'coveralls'
-  require 'simplecov-lcov'
+require 'simplecov'
+require 'coveralls'
+require 'simplecov-lcov'
 
-  SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
 
-  SimpleCov.formatters = [
-    SimpleCov::Formatter::HTMLFormatter,
-    SimpleCov::Formatter::LcovFormatter,
-    Coveralls::SimpleCov::Formatter
-  ]
+SimpleCov.formatters = [
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::LcovFormatter,
+  Coveralls::SimpleCov::Formatter
+]
 
-  SimpleCov.start do
-    add_filter ['/spec/', '/vendor/', 'strategy_macros.rb']
-    minimum_coverage(92.5)
-    maximum_coverage_drop(0.05)
-  end
+SimpleCov.start do
+  add_filter ['/spec/', '/vendor/', 'strategy_macros.rb']
+  minimum_coverage(92.5)
+  maximum_coverage_drop(0.05)
 end
 
 require 'rspec'


### PR DESCRIPTION
Probably more can be removed since Ruby 2.x is now EOL, but the current spec at least only marks 2.2+ support so these conditions shouldn't apply anymore anyway