### PR TITLE
fix: conditional delegate require Rack/JRuby

### DIFF
--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        jruby: [jruby] # TODO: Add back jruby-head once we figure out why there's a bundler mismatch
+        jruby: [jruby, jruby-head]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -1,3 +1,7 @@
+# TODO: Fixed in https://github.com/rack/rack/pull/1610 for Rack 3
+if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
+  require 'delegate'
+end
 require 'rack'
 require 'singleton'
 require 'logger'


### PR DESCRIPTION
This seems kind of hacky, but it seems like the bug in Rack was only fixed in v3, and wasn't backported to v2