### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/omniauth

### DIFF
--- a/omniauth.gemspec
+++ b/omniauth.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2'
   spec.summary       = spec.description
   spec.version       = OmniAuth::VERSION
+  spec.metadata['changelog_uri'] = spec.homepage + '/releases'
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/omniauth which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/