### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/omniauth.gemspec
+++ b/omniauth.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2'
   spec.summary       = spec.description
   spec.version       = OmniAuth::VERSION
+  spec.metadata      = { 'rubygems_mfa_required' => 'true' }
 end


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/