### PR TITLE
Do not override `omniauth.origin` in environment in test mode

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -335,7 +335,9 @@ module OmniAuth
 
     def mock_callback_call
       setup_phase
-      @env['omniauth.origin'] ||= session.delete('omniauth.origin')
+
+      origin = session.delete('omniauth.origin')
+      @env['omniauth.origin'] ||= origin
       @env['omniauth.origin'] = nil if env['omniauth.origin'] == ''
       @env['omniauth.params'] = session.delete('omniauth.params') || {}
 

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -335,7 +335,7 @@ module OmniAuth
 
     def mock_callback_call
       setup_phase
-      @env['omniauth.origin'] = session.delete('omniauth.origin')
+      @env['omniauth.origin'] ||= session.delete('omniauth.origin')
       @env['omniauth.origin'] = nil if env['omniauth.origin'] == ''
       @env['omniauth.params'] = session.delete('omniauth.params') || {}
 

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -854,6 +854,11 @@ describe OmniAuth::Strategy do
             strategy.call(make_env('/auth/test', 'QUERY_STRING' => 'origin=/foo'))
             expect(strategy.env['rack.session']['omniauth.origin']).to eq('/foo')
           end
+
+          it 'does not override omniauth.origin if already set' do
+            strategy.call(make_env('/auth/test', 'omniauth.origin' => '/foo'))
+            expect(strategy.env['omniauth.origin']).to eq('/foo')
+          end
         end
 
         context 'custom' do

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -854,11 +854,6 @@ describe OmniAuth::Strategy do
             strategy.call(make_env('/auth/test', 'QUERY_STRING' => 'origin=/foo'))
             expect(strategy.env['rack.session']['omniauth.origin']).to eq('/foo')
           end
-
-          it 'does not override omniauth.origin if already set' do
-            strategy.call(make_env('/auth/test', 'omniauth.origin' => '/foo'))
-            expect(strategy.env['omniauth.origin']).to eq('/foo')
-          end
         end
 
         context 'custom' do
@@ -875,6 +870,14 @@ describe OmniAuth::Strategy do
 
         strategy.call(make_env('/auth/test/callback', 'rack.session' => {'omniauth.origin' => 'http://example.com/origin'}))
         expect(strategy.env['omniauth.origin']).to eq('http://example.com/origin')
+      end
+
+      it 'does not override omniauth.origin if already set on the callback phase' do
+        strategy.call(make_env('/auth/test/callback',
+          'rack.session' => {'omniauth.origin' => 'http://example.com/origin'},
+          'omniauth.origin' => '/foo'))
+        expect(strategy.env['omniauth.origin']).to eq('/foo')
+        expect(strategy.env['rack.session']['omniauth.origin']).to be_nil
       end
 
       it 'executes callback hook on the callback phase' do


### PR DESCRIPTION
I'm attempting to write a test for our authentication callback Rails controller, however using `ActionDispatch::IntegrationTest` it is not possible to modify the `session`. This change makes it easy to test.

Fixes #934

Example with Rails:

```ruby
class ExampleController < ApplicationController
  def callback
    # Add user to session
    redirect_to(env["omniauth.origin"] || "/")
  end
end

class ExampleControllerTest < ActionDispatch::IntegrationTest
  test "redirects to origin" do
    get "/auth/example/callback", env: {"omniauth.origin" => "/foo"}

    assert_redirected_to "/foo"
  end
end
```