### PR TITLE
Avoid using `URI::ABS_URI`

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -481,7 +481,7 @@ module OmniAuth
         OmniAuth.config.full_host.call(env)
       else
         # in Rack 1.3.x, request.url explodes if scheme is nil
-        if request.scheme && request.url.match(URI::ABS_URI)
+        if request.scheme && URI.parse(request.url).absolute?
           uri = URI.parse(request.url.gsub(/\?.*$/, ''))
           uri.path = ''
           # sometimes the url is actually showing http inside rails because the


### PR DESCRIPTION
`URI::ABS_URI` is no longer available due to a change to https://bugs.ruby-lang.org/issues/19266 .
Instead, we can use `URI#absolute?`.