### PR TITLE
Exclude (macos, 2.5) from test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,9 @@ jobs:
       matrix:
         os: [ubuntu, macos]
         ruby: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, head, debug]
+        exclude:
+        - os: macos
+          ruby: 2.5
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby


### PR DESCRIPTION
CRuby < 2.6 does not support macos-arm64, which is what `macos-latest` runs with.

`macos-latest-large` does still run as x86 if you wanted to use that instead https://github.com/actions/runner-images?tab=readme-ov-file#available-images

Example failed run: https://github.com/omniauth/omniauth/actions/runs/10039676811/job/28362997222