### PR TITLE
Standardize quote usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ To get started, add the following gems
 **Gemfile**:
 ```ruby
 gem 'omniauth'
-gem "omniauth-rails_csrf_protection"
+gem 'omniauth-rails_csrf_protection'
 ```
 
 Then insert OmniAuth as a middleware


### PR DESCRIPTION
Fixed a single instance of double quotes in the README that was inconsistent with the rest of the document. 