### PR TITLE
Simplify login button in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,7 @@ end
 
 **app/views/sessions/new.html.erb**:
 ```erb
-<%= form_tag('/auth/developer', method: 'post', data: {turbo: false}) do %>
-  <button type='submit'>Login with Developer</button>
-<% end %>
+<%= button_to "Login with Developer", "/auth/developer", data: { turbo: false } %>
 ```
 
 Now if you visit `/login` and click the Login button, you should see the


### PR DESCRIPTION
There is a dedicated method for a this use case.
It makes the code shorter and simple to translate into HAML or some other HTML generator. And the documentation of `button_to` is quite clear about the generated HTML tags:  https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-button_to