### PR TITLE
Update OmniAuth configuration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ To get started, add the following gems
 **Gemfile**:
 ```ruby
 gem 'omniauth'
-gem "omniauth-rails_csrf_protection"
 ```
 
 Then insert OmniAuth as a middleware
@@ -126,6 +125,8 @@ Then insert OmniAuth as a middleware
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :developer if Rails.env.development?
 end
+
+OmniAuth.config.request_validation_phase = OmniAuth::AuthenticityTokenProtection.new(key: :_csrf_token)
 ```
 
 Additional providers can be added here in the future. Next we wire it


### PR DESCRIPTION
Removed [omniauth-rails_csrf_protection](https://github.com/cookpad/omniauth-rails_csrf_protection) gem and added request validation phase configuration.

Unless, I don't understand something, there is no reason to have an extra gem since the documentation states we can just add the following line now.

```ruby
OmniAuth.config.request_validation_phase = OmniAuth::AuthenticityTokenProtection.new(key: :_csrf_token)
```